### PR TITLE
fix: remove `null` keys from manifests now only on `NELM_FEAT_CLEAN_NULL_FIELDS=true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Nelm is production-ready: as the werf deployment engine, it was battle-tested ac
   - [`NELM_FEAT_NATIVE_RELEASE_UNINSTALL` environment variable](#nelm_feat_native_release_uninstall-environment-variable)
   - [`NELM_FEAT_PERIODIC_STACK_TRACES` environment variable](#nelm_feat_periodic_stack_traces-environment-variable)
   - [`NELM_FEAT_FIELD_SENSITIVE` environment variable](#nelm_feat_field_sensitive-environment-variable)
+  - [`NELM_FEAT_CLEAN_NULL_FIELDS` environment variable](#nelm_feat_clean_null_fields-environment-variable)
 - [More documentation](#more-documentation)
 - [Future plans](#future-plans)
 - [Limitations](#limitations)
@@ -811,6 +812,18 @@ Example:
 ```shell
 export NELM_FEAT_FIELD_SENSITIVE=true
 nelm release plan install -n myproject -r myproject
+```
+
+### `NELM_FEAT_CLEAN_NULL_FIELDS` environment variable
+
+Improve Helm chart compatibility. When rendering charts, remove keys with `null` values from the rendered resource manifests, before applying them. Otherwise, SSA often fail on `null` values, which didn't happen with 3WM.
+
+Will be the default in the next major release.
+
+Example:
+```shell
+export NELM_FEAT_CLEAN_NULL_FIELDS=true
+nelm release install -n myproject -r myproject
 ```
 
 ## More documentation

--- a/internal/resource/spec/resource_spec.go
+++ b/internal/resource/spec/resource_spec.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/werf/nelm/pkg/common"
+	"github.com/werf/nelm/pkg/featgate"
 )
 
 type ResourceSpec struct {
@@ -27,7 +28,7 @@ type ResourceSpecOptions struct {
 
 func NewResourceSpec(unstruct *unstructured.Unstructured, releaseNamespace string, opts ResourceSpecOptions) *ResourceSpec {
 	unstruct = CleanUnstruct(unstruct, CleanUnstructOptions{
-		CleanNullFields: !opts.LegacyNoCleanNullFields,
+		CleanNullFields: (featgate.FeatGatePreviewV2.Enabled() || featgate.FeatCleanNullFields.Enabled()) && !opts.LegacyNoCleanNullFields,
 	})
 
 	if opts.StoreAs == "" {

--- a/pkg/featgate/feat.go
+++ b/pkg/featgate/feat.go
@@ -41,6 +41,11 @@ var (
 		"preview-v2",
 		`Activate all feature gates that will be enabled by default in Nelm v2`,
 	)
+
+	FeatCleanNullFields = NewFeatGate(
+		"clean-null-fields",
+		`Enable cleaning of null fields from resource manifests for better Helm chart compatibility`,
+	)
 )
 
 type FeatGate struct {


### PR DESCRIPTION
Removing `null`s resulted in removing empty keys from ConfigMaps