### PR TITLE
fix: adjust sensitive changes tracking for Secret.

### DIFF
--- a/internal/plan/planned_changes.go
+++ b/internal/plan/planned_changes.go
@@ -182,16 +182,12 @@ func buildDelChanges(delInfos []*DeletableResourceInfo, opts CalculatePlannedCha
 	return changes, nil
 }
 
-func hasChangedSensitiveInfo(resMeta *spec.ResourceMeta, oldUndsruct, newUnstruct *unstructured.Unstructured) bool {
-	if resMeta.GroupVersionKind.GroupKind().Kind != "Secret" {
-		return false
-	}
-
+func hasChangedSensitiveInfo(oldUnstruct, newUnstruct *unstructured.Unstructured) bool {
 	hasChanged := lo.SomeBy([]string{"data", "stringData"}, func(dataKey string) bool {
 		var oldData, newData map[string]interface{}
 
-		if oldUndsruct != nil {
-			oldData, _, _ = unstructured.NestedMap(oldUndsruct.Object, dataKey)
+		if oldUnstruct != nil {
+			oldData, _, _ = unstructured.NestedMap(oldUnstruct.Object, dataKey)
 		}
 
 		if newUnstruct != nil {
@@ -212,7 +208,7 @@ func buildResourceChange(resMeta *spec.ResourceMeta, oldUnstruct, newUnstruct *u
 		!opts.ShowVerboseCRDDiffs &&
 		(oldUnstruct == nil || newUnstruct == nil) {
 		uDiff = HiddenVerboseCRDChanges
-	} else if sensitiveInfo.FullySensitive() && !opts.ShowSensitiveDiffs && hasChangedSensitiveInfo(resMeta, oldUnstruct, newUnstruct) {
+	} else if sensitiveInfo.FullySensitive() && !opts.ShowSensitiveDiffs && hasChangedSensitiveInfo(oldUnstruct, newUnstruct) {
 		uDiff = HiddenSensitiveChanges
 	} else if !opts.ShowVerboseDiffs && (oldUnstruct == nil || newUnstruct == nil) {
 		uDiff = HiddenVerboseChanges


### PR DESCRIPTION
Adjust sensitive changes tracking for Secret. If there is no really changed sensitive info (data/stringData) -  message `<hidden insignificant changes>` should be displayed.

To test PR, use the next chart:
```
--- deployment.yaml---

apiVersion: apps/v1
kind: Deployment
metadata:
  name: task-chart
spec:
  replicas: 1
  selector:
    matchLabels:
      app: task-chart
  template:
    metadata:
      labels:
        app: task-chart
    spec:
      containers:
        - name: pi
          image: perl:5.34.0
          command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
          envFrom:
            - secretRef:
                name: app-envs

---secret-app-evns.yaml---

apiVersion: v1
kind: Secret
metadata:
  name: app-envs
  labels:
    test: some-string
type: Opaque
data:
  pass: {{ .Values.appEnv.pass1 | b64enc }}
  pass2: {{ .Values.appEnv.pass2 | b64enc }}

---secret-values.yaml---

appEnv:
  pass1: <YourEncryptedString>
  pass2: <YourEncryptedString>

```

Run `nelm release install ...`. Then, change one of secret passwords (for example pass1) and run `nelm release plan install ...` and next message will be displayed as planned:
```
┌ Update Secret/app-envs
│ <hidden sensitive changes>
└ Update Secret/app-envs
```
Undo password changes, change `test: some-string` in secret-app-evns.yaml and run `nelm release plan install` again:
```
┌ Update Secret/app-envs
│ <hidden insignificant changes>
└ Update Secret/app-envs
```
The message above is correct, because there is no password changes. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Enhances the precision of secret change detection for Secret resources by updating logic to ensure only significant changes to sensitive data trigger an explicit update message, preventing false alerts for insignificant modifications.</li>

<li>Introduces a new helper function and integrates hasChangedSensitiveInfo to refine sensitive information tracking logic for Secret resources.</li>

<li>Removes a redundant parameter from the sensitive changes tracking mechanism.</li>

<li>Modifies conditional checks in the sensitive changes tracking mechanism to ensure only meaningful modifications to sensitive fields trigger explicit updates.</li>

<li>Adds the reflect import to facilitate deep comparisons.</li>

<li>Overall, these changes refine the sensitive changes tracking mechanism for Secret resources by adjusting function parameters and conditional checks, improving the precision and reliability of secret change detection and the release planning process in handling sensitive data changes.</li>

</ul>

</div>