### PR TITLE
Fixes for nelm chart init --ts

### DIFF
--- a/internal/ts/init_templates.go
+++ b/internal/ts/init_templates.go
@@ -7,7 +7,7 @@ const (
 name: %s
 version: 0.1.0
 `
-	deploymentTSContent = `import { RenderContext } from '@nelm/types';
+	deploymentTSContent = `import type { RenderContext } from '@nelm/chart-ts-sdk';
 import { getFullname, getLabels, getSelectorLabels } from './helpers';
 
 export function newDeployment($: RenderContext): object {
@@ -33,7 +33,7 @@ export function newDeployment($: RenderContext): object {
           containers: [
             {
               name: name,
-              image: ` + "`${$.Values.image?.repository}:${$.Values.image?.tag}`" + `,
+              image: ` + "($.Values.image?.repository ?? 'nginx') + ':' + ($.Values.image?.tag ?? 'latest')" + `,
               ports: [
                 {
                   name: 'http',
@@ -55,7 +55,7 @@ export function newDeployment($: RenderContext): object {
 # TypeScript chart files
 ts/dist/
 `
-	helpersTSContent = `import { RenderContext } from '@nelm/types';
+	helpersTSContent = `import type { RenderContext } from '@nelm/chart-ts-sdk';
 
 /**
  * Truncate string to max length, removing trailing hyphens.
@@ -97,7 +97,7 @@ export function getSelectorLabels($: RenderContext): Record<string, string> {
   };
 }
 `
-	indexTSContent = `import { RenderContext, RenderResult } from '@nelm/types';
+	indexTSContent = `import type { RenderContext, RenderResult } from '@nelm/chart-ts-sdk';
 import { newDeployment } from './deployment';
 import { newService } from './service';
 
@@ -119,7 +119,7 @@ export function render($: RenderContext): RenderResult {
   "description": "TypeScript chart for %s",
   "main": "src/index.ts",
   "scripts": {
-    "build": "npx tsc --noEmit",
+    "build": "npx tsc",
     "typecheck": "npx tsc --noEmit"
   },
   "keywords": [
@@ -130,14 +130,14 @@ export function render($: RenderContext): RenderResult {
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@nelm/types": "^0.1.0"
+    "@nelm/chart-ts-sdk": "^0.1.2"
   },
   "devDependencies": {
     "typescript": "^5.0.0"
   }
 }
 `
-	serviceTSContent = `import { RenderContext } from '@nelm/types';
+	serviceTSContent = `import type { RenderContext } from '@nelm/chart-ts-sdk';
 import { getFullname, getLabels, getSelectorLabels } from './helpers';
 
 export function newService($: RenderContext): object {

--- a/internal/ts/init_test.go
+++ b/internal/ts/init_test.go
@@ -271,7 +271,7 @@ func TestInitTSBoilerplate(t *testing.T) {
 		assert.Contains(t, string(serviceContent), "export function newService")
 	})
 
-	t.Run("includes @nelm/types dependency", func(t *testing.T) {
+	t.Run("includes @nelm/chart-ts-sdk dependency", func(t *testing.T) {
 		chartPath := filepath.Join(t.TempDir(), "test-chart")
 		require.NoError(t, os.MkdirAll(chartPath, 0o755))
 
@@ -280,7 +280,7 @@ func TestInitTSBoilerplate(t *testing.T) {
 
 		content, err := os.ReadFile(filepath.Join(chartPath, "ts", "package.json"))
 		require.NoError(t, err)
-		assert.Contains(t, string(content), `"@nelm/types"`)
+		assert.Contains(t, string(content), `"@nelm/chart-ts-sdk"`)
 	})
 
 	t.Run("includes correct tsconfig.json options", func(t *testing.T) {


### PR DESCRIPTION
This is fixes for issues with Typescript initialization mentioned in https://github.com/werf/nelm/issues/547

- [x] If values.yaml already exist in the chart the moment we call nelm chart init --ts, then there are no values.yaml generated and an image in the deployment becomes undefined:undefined. Fallback needed. Probably this: image: ($.Values.image?.repository ?? 'nginx') + ':' + ($.Values.image?.tag ?? 'latest')
- [x] Nelm SDK npm package name is wrong both in package.json and src files generated by nelm chart init --ts
- [x] --noEmit in scripts in package.json? Probably these scripts need revision

Also instead of just `import` now use `import type` to mark explicitly only types are
used this package can be build without installing any packages.
