### PR TITLE
chore(taskfile): use shared lint/format tasks from common-ci

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -13,6 +13,7 @@ defaults:
 
 env:
   DEBIAN_FRONTEND: "noninteractive"
+  TASK_X_REMOTE_TASKFILES: 1
 
 jobs:
   _:
@@ -35,7 +36,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install golangci-lint
-        run: task -p deps:install:golangci-lint
+        run: task --yes -p deps:install:golangci-lint
 
       - name: Lint
-        run: task -p lint
+        run: task --yes -p lint

--- a/.github/workflows/_test_unit.yml
+++ b/.github/workflows/_test_unit.yml
@@ -22,6 +22,7 @@ defaults:
 
 env:
   DEBIAN_FRONTEND: "noninteractive"
+  TASK_X_REMOTE_TASKFILES: 1
 
 jobs:
   _:
@@ -47,7 +48,7 @@ jobs:
 
       # TODO: don't build ginkgo everytime? We need distributable binaries
       - name: Install ginkgo
-        run: task -p deps:install:ginkgo
+        run: task --yes -p deps:install:ginkgo
 
       - name: Prepare coverage dir
         if: ${{ inputs.coverage }}
@@ -59,7 +60,7 @@ jobs:
             task -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --coverprofile="$(openssl rand -hex 6)-coverage.out" --keep-going --skip-package '${{ inputs.excludePackages }}'
             mv *-coverage.out "$GITHUB_WORKSPACE/coverage/"
           else
-            task -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --keep-going --skip-package '${{ inputs.excludePackages }}'
+            task --yes -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --keep-going --skip-package '${{ inputs.excludePackages }}'
           fi
           echo loadavg: $(cat /proc/loadavg)
 

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -91,7 +91,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: task -p build:dev:all
+        run: task --yes -p build:dev:all
+        env:
+          TASK_X_REMOTE_TASKFILES: 1
 
   notify:
     if: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /\*\*
 /.env
 /.env.\*
+.task
 /secrets
 
 *.swp

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -6,6 +6,23 @@ env:
   GO111MODULE: "on"
   CGO_ENABLED: "0"
 
+includes:
+  lint:
+    taskfile: https://raw.githubusercontent.com/werf/common-ci/chore/update-taskfile-for-nelm/Taskfile.format_lint.yml
+    flatten: true
+    vars:
+      golangciConfig: ".golangci_strict.yml"
+      golangciLintVersion: "v2.5.0"
+      golangciPaths: "./internal/... ./pkg/... ./cmd/..."
+      paths: "./internal/ ./pkg/ ./cmd/"
+      gciPrefix: '{{slice (splitList "/" .package) 0 2 | join "/"}}'
+      enableGolangciLintFormat: "true"
+  deps:
+    taskfile: https://raw.githubusercontent.com/werf/common-ci/main/Taskfile.deps.yml
+    flatten: true
+    vars:
+      golangciLintVersion: "v2.5.0"
+
 vars:
   brand: "Nelm"
   brandSlug: "nelm"
@@ -47,14 +64,6 @@ tasks:
     cmds:
       - go build -o "{{.outputDir | default (printf "./dist/%s/%s-%s/bin" .version .targetOS .targetArch)}}/{{.brandSlug}}{{if (eq .targetOS "windows")}}.exe{{end}}"
         -ldflags="{{.ldFlags}}" -tags="{{.ctags}}" {{.extraGoBuildArgs}} {{.CLI_ARGS}} {{.pkg | default .package}}
-
-  _golangci-lint:
-    internal: true
-    run: once
-    cmds:
-      - golangci-lint run {{if eq .fix "true"}}--fix{{end}} --build-tags="{{.tags}}" {{.CLI_ARGS}} {{.paths | default "./..."}}
-    vars:
-      paths: "{{.paths}}"
 
   build:
     desc: "Build main dev binary."
@@ -234,43 +243,6 @@ tasks:
     cmds:
       - ./scripts/verify-dist-binaries.sh {{.version}}
 
-  format:
-    desc: 'Run all code formatters. Important vars: "paths".'
-    run: once
-    cmds:
-      - task: format:gci
-      - task: format:gofumpt
-      - task: format:prettier
-      - task: format:golangci-lint
-
-  format:gci:
-    desc: 'Format code with gci. Important vars: "paths".'
-    cmds:
-      - gci write -s Standard -s Default -s 'Prefix({{slice (splitList "/" .package) 0 2 | join "/"}})' {{.CLI_ARGS}} {{.paths | default "internal/ pkg/ cmd/"}}
-
-  format:gofumpt:
-    desc: 'Format code with gofumpt. Important vars: "paths".'
-    cmds:
-      - gofumpt -extra -w {{.CLI_ARGS}} {{.paths | default "internal/ cmd/ pkg/"}}
-
-  format:golangci-lint:
-    desc: 'Format with golangci-lint. Important vars: "paths".'
-    cmds:
-      - task: _golangci-lint
-        vars:
-          fix: "true"
-          paths: "{{.paths}}"
-
-  format:prettier:
-    desc: "Format with prettier."
-    deps:
-      - format:prettier:yaml
-
-  format:prettier:yaml:
-    desc: "Format yaml files with prettier."
-    cmds:
-      - docker run --rm -u "$(id -u):$(id -g)" -v $(pwd):/work tmknom/prettier -w "**/*.yaml" "**/*.yml"
-
   generate:
     desc: 'Run all generators. Important vars: "paths".'
     run: once
@@ -281,30 +253,6 @@ tasks:
     desc: "Generate Tables of Contents in Markdown files."
     cmds:
       - docker run --rm -v "$(pwd)":/work peterdavehello/npm-doctoc doctoc --update-only /work
-
-  lint:
-    desc: 'Run all linters in parallel. Important vars: "paths".'
-    deps:
-      - lint:golangci-lint
-      - lint:prettier
-
-  lint:golangci-lint:
-    desc: 'Lint with golangci-lint. Important vars: "paths".'
-    cmds:
-      - task: _golangci-lint
-        vars:
-          fix: "false"
-          paths: "{{.paths}}"
-
-  lint:prettier:
-    desc: "Check if prettier-formatted."
-    deps:
-      - lint:prettier:yaml
-
-  lint:prettier:yaml:
-    desc: "Check if yaml files are prettier-formatted."
-    cmds:
-      - docker run --rm -u "$(id -u):$(id -g)" -v $(pwd):/work tmknom/prettier -c "**/*.yaml" "**/*.yml"
 
   github:dispatch:nelm:
     desc: 'Manually dispatch specified GitHub workflow. Important vars: "eventType", "githubToken".'
@@ -369,36 +317,6 @@ tasks:
     desc: "Clean built release binaries."
     cmds:
       - rm -rf ./dist
-
-  deps:install:
-    desc: "Install all dependencies"
-    deps:
-      - deps:install:gci
-      - deps:install:ginkgo
-      - deps:install:gofumpt
-      - deps:install:golangci-lint
-
-  deps:install:gci:
-    desc: "Install gci binary."
-    cmds:
-      - go install github.com/daixiang0/gci@v0.13.5
-
-  deps:install:ginkgo:
-    desc: "Install ginkgo binary."
-    cmds:
-      - |
-        version="$(go list -m -f '{{ printf `{{ .Version }}` }}' github.com/onsi/ginkgo/v2)"
-        go install {{.CLI_ARGS}} github.com/onsi/ginkgo/v2/ginkgo@${version}
-
-  deps:install:gofumpt:
-    desc: "Install gofumpt binary."
-    cmds:
-      - go install mvdan.cc/gofumpt@v0.7.0
-
-  deps:install:golangci-lint:
-    desc: "Install golangci-lint binary."
-    cmds:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {{.golangcilintVersion | default "v2.5.0"}}
 
   sign:
     desc: 'Sign last version tag + origin/main and push signatures. Important vars: "refs".'


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request refactors the Taskfile.dist.yaml to utilize shared lint and format tasks from the common-ci repository, eliminating duplicated task definitions and enhancing maintainability across projects.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds includes for shared lint and deps taskfiles from werf/common-ci repository in Taskfile.dist.yaml</li>

<li>Removes local definitions of lint, format, and dependency installation tasks from Taskfile.dist.yaml</li>

<li>Centralizes CI task management to improve consistency and reduce maintenance overhead</li>

</ul>
</details>

</div>