### PR TITLE
chore: LegacyProgressReportCh option for ReleaseInstall/Uninstall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Nelm is a Go-based Kubernetes deployment tool, which deploys Helm charts, is com
 - ALWAYS validate early, validate a lot. ALWAYS keep APIs stupid and minimal.
 - NEVER prefer global state. ALWAYS prefer simplicity over micro-optimizations.
 - ALWAYS use libraries for complex things instead of reinventing the wheel.
-- NEVER add comments unless they document a public API or explain genuinely non-obvious logic. NEVER add obvious/redundant comments, NEVER add comments restating what code does. When in doubt, don't comment.
+- NEVER add comments unless they document a non-obvious public API or explain genuinely non-obvious logic. NEVER add obvious/redundant comments, NEVER add comments restating what code does. When in doubt, don't comment.
 
 ### Conventions
 

--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -15,7 +15,7 @@
 * Avoid global state.
 * Prefer simplicity over micro-optimizations.
 * For complex things use libraries instead of reinventing the wheel.
-* Document only public APIs or complex/weird code.
+* Document only non-obvious public APIs or complex/weird code.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Nelm is production-ready: as the werf deployment engine, it was battle-tested ac
 - [More documentation](#more-documentation)
 - [Limitations](#limitations)
 - [Contributing](#contributing)
+- [Special thanks](#special-thanks)
 - [Future plans](#future-plans)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/internal/plan/helpers_ai_test.go
+++ b/internal/plan/helpers_ai_test.go
@@ -1,0 +1,97 @@
+//go:build ai_tests
+
+package plan
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/werf/nelm/internal/resource/spec"
+	"github.com/werf/nelm/pkg/legacy/progrep"
+)
+
+type fakeRESTMapper struct {
+	meta.RESTMapper
+	mappings map[schema.GroupKind]*meta.RESTMapping
+}
+
+func newFakeRESTMapper() *fakeRESTMapper {
+	namespacedScope := meta.RESTScopeNamespace
+	clusterScope := meta.RESTScopeRoot
+
+	return &fakeRESTMapper{
+		mappings: map[schema.GroupKind]*meta.RESTMapping{
+			{Group: "", Kind: "ConfigMap"}:      {Scope: namespacedScope},
+			{Group: "", Kind: "Service"}:        {Scope: namespacedScope},
+			{Group: "apps", Kind: "Deployment"}: {Scope: namespacedScope},
+			{Group: "", Kind: "Namespace"}:      {Scope: clusterScope},
+		},
+	}
+}
+
+func (m *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	if mapping, ok := m.mappings[gk]; ok {
+		return mapping, nil
+	}
+
+	return nil, fmt.Errorf("no mapping for %v", gk)
+}
+
+func makeResourceMeta(name, namespace string, gvk schema.GroupVersionKind) *spec.ResourceMeta {
+	return &spec.ResourceMeta{
+		Name:             name,
+		Namespace:        namespace,
+		GroupVersionKind: gvk,
+	}
+}
+
+func makeResourceSpec(name, namespace string, gvk schema.GroupVersionKind) *spec.ResourceSpec {
+	return &spec.ResourceSpec{
+		ResourceMeta: makeResourceMeta(name, namespace, gvk),
+	}
+}
+
+var (
+	gvkConfigMap  = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	gvkService    = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+	gvkDeployment = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	gvkNamespace  = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	gvkCRD        = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}
+)
+
+func buildTestPlan(ops []*Operation, deps map[int][]int) *Plan {
+	p := NewPlan()
+
+	for _, op := range ops {
+		if err := p.Graph.AddVertex(op); err != nil {
+			panic(fmt.Sprintf("add vertex: %v", err))
+		}
+	}
+
+	if deps != nil {
+		for toIdx, fromIdxs := range deps {
+			for _, fromIdx := range fromIdxs {
+				if err := p.Graph.AddEdge(ops[fromIdx].ID(), ops[toIdx].ID()); err != nil {
+					panic(fmt.Sprintf("add edge: %v", err))
+				}
+			}
+		}
+	}
+
+	return p
+}
+
+func drainChannel(ch <-chan progrep.ProgressReport) []progrep.ProgressReport {
+	var reports []progrep.ProgressReport
+
+	for {
+		select {
+		case r := <-ch:
+			reports = append(reports, r)
+		default:
+			return reports
+		}
+	}
+}

--- a/internal/plan/legacy_progress_report.go
+++ b/internal/plan/legacy_progress_report.go
@@ -1,0 +1,139 @@
+package plan
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/werf/nelm/internal/resource/spec"
+	"github.com/werf/nelm/pkg/legacy/progrep"
+)
+
+func reportOperationStatus(op *Operation, status OperationStatus, reporter *LegacyProgressReporter) {
+	op.Status = status
+
+	if reporter == nil {
+		return
+	}
+
+	reporter.ReportStatus(op.ID(), mapOperationStatus(status))
+}
+
+// operationResourceMeta extracts GVK, name, and namespace from an operation's
+// config. Returns ok=false for operation configs that don't carry resource metadata
+// (e.g. Noop, release operations).
+func operationResourceMeta(config OperationConfig) (gvk schema.GroupVersionKind, name, namespace string, ok bool) {
+	switch c := config.(type) {
+	case *OperationConfigCreate:
+		return c.ResourceSpec.GroupVersionKind, c.ResourceSpec.Name, c.ResourceSpec.Namespace, true
+	case *OperationConfigUpdate:
+		return c.ResourceSpec.GroupVersionKind, c.ResourceSpec.Name, c.ResourceSpec.Namespace, true
+	case *OperationConfigApply:
+		return c.ResourceSpec.GroupVersionKind, c.ResourceSpec.Name, c.ResourceSpec.Namespace, true
+	case *OperationConfigRecreate:
+		return c.ResourceSpec.GroupVersionKind, c.ResourceSpec.Name, c.ResourceSpec.Namespace, true
+	case *OperationConfigDelete:
+		return c.ResourceMeta.GroupVersionKind, c.ResourceMeta.Name, c.ResourceMeta.Namespace, true
+	case *OperationConfigTrackReadiness:
+		return c.ResourceMeta.GroupVersionKind, c.ResourceMeta.Name, c.ResourceMeta.Namespace, true
+	case *OperationConfigTrackPresence:
+		return c.ResourceMeta.GroupVersionKind, c.ResourceMeta.Name, c.ResourceMeta.Namespace, true
+	case *OperationConfigTrackAbsence:
+		return c.ResourceMeta.GroupVersionKind, c.ResourceMeta.Name, c.ResourceMeta.Namespace, true
+	default:
+		return schema.GroupVersionKind{}, "", "", false
+	}
+}
+
+func buildResolvedNamespaces(p *Plan, releaseNamespace string, mapper meta.RESTMapper) map[string]string {
+	resolved := make(map[string]string)
+
+	for _, op := range p.Operations() {
+		if op.Category != OperationCategoryResource && op.Category != OperationCategoryTrack {
+			continue
+		}
+
+		gvk, _, ns, ok := operationResourceMeta(op.Config)
+		if !ok {
+			continue
+		}
+
+		resolved[op.ID()] = resolveNamespace(gvk, ns, releaseNamespace, mapper)
+	}
+
+	return resolved
+}
+
+func resolveNamespace(gvk schema.GroupVersionKind, ns, releaseNamespace string, mapper meta.RESTMapper) string {
+	namespaced, err := spec.Namespaced(gvk, mapper)
+	if err != nil {
+		// Graceful CRD fallback: if GVK is unknown, assume namespaced.
+		if ns != "" {
+			return ns
+		}
+
+		return releaseNamespace
+	}
+
+	if !namespaced {
+		return ""
+	}
+
+	if ns != "" {
+		return ns
+	}
+
+	return releaseNamespace
+}
+
+func extractObjectRef(op *Operation, resolvedNamespaces map[string]string) progrep.ObjectRef {
+	gvk, name, _, ok := operationResourceMeta(op.Config)
+	if !ok {
+		panic(fmt.Sprintf("unexpected operation config type %T for operation %s", op.Config, op.ID()))
+	}
+
+	return progrep.ObjectRef{
+		GroupVersionKind: gvk,
+		Name:             name,
+		Namespace:        resolvedNamespaces[op.ID()],
+	}
+}
+
+func mapOperationType(t OperationType) progrep.OperationType {
+	switch t {
+	case OperationTypeCreate:
+		return progrep.OperationTypeCreate
+	case OperationTypeUpdate:
+		return progrep.OperationTypeUpdate
+	case OperationTypeDelete:
+		return progrep.OperationTypeDelete
+	case OperationTypeApply:
+		return progrep.OperationTypeApply
+	case OperationTypeRecreate:
+		return progrep.OperationTypeRecreate
+	case OperationTypeTrackReadiness:
+		return progrep.OperationTypeTrackReadiness
+	case OperationTypeTrackPresence:
+		return progrep.OperationTypeTrackPresence
+	case OperationTypeTrackAbsence:
+		return progrep.OperationTypeTrackAbsence
+	default:
+		panic(fmt.Sprintf("unexpected operation type %q", t))
+	}
+}
+
+func mapOperationStatus(s OperationStatus) progrep.OperationStatus {
+	switch s {
+	case OperationStatusUnknown:
+		return progrep.OperationStatusPending
+	case OperationStatusPending:
+		return progrep.OperationStatusProgressing
+	case OperationStatusCompleted:
+		return progrep.OperationStatusCompleted
+	case OperationStatusFailed:
+		return progrep.OperationStatusFailed
+	default:
+		return progrep.OperationStatusPending
+	}
+}

--- a/internal/plan/legacy_progress_reporter.go
+++ b/internal/plan/legacy_progress_reporter.go
@@ -1,0 +1,179 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	kdutil "github.com/werf/kubedog/pkg/trackers/dyntracker/util"
+	"github.com/werf/nelm/pkg/legacy/progrep"
+)
+
+type LegacyProgressReporter struct {
+	state    *kdutil.Concurrent[*progressReporterState]
+	reportCh chan<- progrep.ProgressReport
+}
+
+type progressReporterState struct {
+	frozen  []progrep.StageReport
+	ops     []opEntry
+	opIndex map[string]int
+}
+
+type opEntry struct {
+	ref         progrep.ObjectRef
+	typ         progrep.OperationType
+	status      progrep.OperationStatus
+	predIndices []int
+}
+
+func NewLegacyProgressReporter(reportCh chan<- progrep.ProgressReport) *LegacyProgressReporter {
+	if cap(reportCh) < 1 {
+		panic(fmt.Sprintf("LegacyProgressReportCh must be a buffered channel with capacity >= 1, got capacity %d", cap(reportCh)))
+	}
+
+	return &LegacyProgressReporter{
+		state: kdutil.NewConcurrent(&progressReporterState{
+			opIndex: make(map[string]int),
+		}),
+		reportCh: reportCh,
+	}
+}
+
+func (r *LegacyProgressReporter) ReportStatus(opID string, status progrep.OperationStatus) {
+	r.state.RWTransaction(func(s *progressReporterState) {
+		idx, ok := s.opIndex[opID]
+		if !ok {
+			return
+		}
+
+		s.ops[idx].status = status
+
+		report := buildProgressReport(s.frozen, s.ops)
+		sendNonBlocking(r.reportCh, report)
+	})
+}
+
+func (r *LegacyProgressReporter) Stop(ctx context.Context) {
+	var report progrep.ProgressReport
+
+	r.state.RWTransaction(func(s *progressReporterState) {
+		report = buildProgressReport(s.frozen, s.ops)
+	})
+
+	select {
+	case r.reportCh <- report:
+	case <-ctx.Done():
+	}
+}
+
+func (r *LegacyProgressReporter) startStage(p *Plan, resolvedNamespaces map[string]string) {
+	r.state.RWTransaction(func(s *progressReporterState) {
+		if len(s.ops) > 0 {
+			s.frozen = append(s.frozen, buildStageReport(s.ops))
+		}
+
+		predMap := lo.Must(p.Graph.PredecessorMap())
+		ops := p.Operations()
+
+		var entries []opEntry
+
+		entryIndex := make(map[string]int)
+
+		for _, op := range ops {
+			if op.Category != OperationCategoryResource && op.Category != OperationCategoryTrack {
+				continue
+			}
+
+			ref := extractObjectRef(op, resolvedNamespaces)
+			typ := mapOperationType(op.Type)
+			idx := len(entries)
+			entryIndex[op.ID()] = idx
+
+			entries = append(entries, opEntry{
+				ref:    ref,
+				typ:    typ,
+				status: progrep.OperationStatusPending,
+			})
+		}
+
+		for _, op := range ops {
+			idx, ok := entryIndex[op.ID()]
+			if !ok {
+				continue
+			}
+
+			var predIndices []int
+			for predID := range predMap[op.ID()] {
+				if predIdx, predOk := entryIndex[predID]; predOk {
+					predIndices = append(predIndices, predIdx)
+				}
+			}
+
+			entries[idx].predIndices = predIndices
+		}
+
+		s.ops = entries
+		s.opIndex = entryIndex
+
+		report := buildProgressReport(s.frozen, s.ops)
+		sendNonBlocking(r.reportCh, report)
+	})
+}
+
+func buildStageReport(ops []opEntry) progrep.StageReport {
+	operations := make([]progrep.Operation, len(ops))
+	for i, e := range ops {
+		operations[i] = progrep.Operation{
+			ObjectRef: e.ref,
+			Type:      e.typ,
+			Status:    e.status,
+		}
+	}
+
+	return progrep.StageReport{
+		Operations: operations,
+	}
+}
+
+func buildProgressReport(frozen []progrep.StageReport, ops []opEntry) progrep.ProgressReport {
+	stageReports := make([]progrep.StageReport, 0, len(frozen)+1)
+
+	for _, sr := range frozen {
+		opsCopy := make([]progrep.Operation, len(sr.Operations))
+		copy(opsCopy, sr.Operations)
+		stageReports = append(stageReports, progrep.StageReport{Operations: opsCopy})
+	}
+
+	operations := make([]progrep.Operation, len(ops))
+	for i, e := range ops {
+		var waitingFor []progrep.ObjectRef
+
+		for _, predIdx := range e.predIndices {
+			if ops[predIdx].status != progrep.OperationStatusCompleted {
+				waitingFor = append(waitingFor, ops[predIdx].ref)
+			}
+		}
+
+		operations[i] = progrep.Operation{
+			ObjectRef:  e.ref,
+			Type:       e.typ,
+			Status:     e.status,
+			WaitingFor: waitingFor,
+		}
+	}
+
+	stageReports = append(stageReports, progrep.StageReport{Operations: operations})
+
+	return progrep.ProgressReport{
+		StageReports: stageReports,
+	}
+}
+
+func sendNonBlocking(ch chan<- progrep.ProgressReport, report progrep.ProgressReport) {
+	select {
+	case ch <- report:
+	default:
+	}
+}

--- a/internal/plan/legacy_progress_reporter_ai_test.go
+++ b/internal/plan/legacy_progress_reporter_ai_test.go
@@ -1,0 +1,577 @@
+//go:build ai_tests
+
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/werf/nelm/pkg/legacy/progrep"
+)
+
+func TestAI_NewLegacyProgressReporter_PanicsOnUnbufferedChannel(t *testing.T) {
+	ch := make(chan progrep.ProgressReport)
+
+	assert.Panics(t, func() {
+		NewLegacyProgressReporter(ch)
+	})
+}
+
+func TestAI_NewLegacyProgressReporter_AcceptsBufferedChannel(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 1)
+
+	assert.NotPanics(t, func() {
+		r := NewLegacyProgressReporter(ch)
+		assert.NotNil(t, r)
+	})
+}
+
+func TestAI_ReportStatus_SendsSnapshot(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 64)
+	reporter := NewLegacyProgressReporter(ch)
+
+	ops := []*Operation{
+		{
+			Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+			Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+		},
+		{
+			Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+			Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("svc1", "", gvkService)},
+		},
+	}
+	p := buildTestPlan(ops, nil)
+
+	resolvedNS := map[string]string{
+		ops[0].ID(): "default",
+		ops[1].ID(): "default",
+	}
+
+	reporter.startStage(p, resolvedNS)
+	drainChannel(ch)
+
+	reporter.ReportStatus(ops[0].ID(), progrep.OperationStatusCompleted)
+
+	reports := drainChannel(ch)
+	require.NotEmpty(t, reports, "expected at least one report after ReportStatus")
+
+	last := reports[len(reports)-1]
+	require.Len(t, last.StageReports, 1)
+
+	activeOps := last.StageReports[0].Operations
+	require.Len(t, activeOps, 2)
+
+	opStatuses := map[string]progrep.OperationStatus{}
+	for _, op := range activeOps {
+		opStatuses[op.Name] = op.Status
+	}
+
+	assert.Equal(t, progrep.OperationStatusCompleted, opStatuses["cm1"])
+	assert.Equal(t, progrep.OperationStatusPending, opStatuses["svc1"])
+}
+
+func TestAI_ReportStatus_UnknownOpIDIsIgnored(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 64)
+	reporter := NewLegacyProgressReporter(ch)
+
+	ops := []*Operation{
+		{
+			Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+			Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+		},
+	}
+	p := buildTestPlan(ops, nil)
+
+	reporter.startStage(p, map[string]string{ops[0].ID(): "default"})
+	drainChannel(ch)
+
+	reporter.ReportStatus("nonexistent/op/id", progrep.OperationStatusCompleted)
+
+	reports := drainChannel(ch)
+	assert.Empty(t, reports, "expected no report for unknown op ID")
+}
+
+func TestAI_StartStage_FreezesPreviousStage(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 64)
+	reporter := NewLegacyProgressReporter(ch)
+
+	ops1 := []*Operation{
+		{
+			Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+			Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+		},
+	}
+	p1 := buildTestPlan(ops1, nil)
+	reporter.startStage(p1, map[string]string{ops1[0].ID(): "default"})
+
+	reporter.ReportStatus(ops1[0].ID(), progrep.OperationStatusCompleted)
+	drainChannel(ch)
+
+	ops2 := []*Operation{
+		{
+			Type: OperationTypeDelete, Version: OperationVersionDelete, Category: OperationCategoryResource,
+			Config: &OperationConfigDelete{ResourceMeta: makeResourceMeta("svc1", "", gvkService)},
+		},
+	}
+	p2 := buildTestPlan(ops2, nil)
+	reporter.startStage(p2, map[string]string{ops2[0].ID(): "default"})
+
+	reports := drainChannel(ch)
+	require.NotEmpty(t, reports)
+
+	last := reports[len(reports)-1]
+	require.Len(t, last.StageReports, 2, "expected frozen stage + active stage")
+
+	frozenOps := last.StageReports[0].Operations
+	require.Len(t, frozenOps, 1)
+	assert.Equal(t, "cm1", frozenOps[0].Name)
+	assert.Equal(t, progrep.OperationStatusCompleted, frozenOps[0].Status)
+
+	activeOps := last.StageReports[1].Operations
+	require.Len(t, activeOps, 1)
+	assert.Equal(t, "svc1", activeOps[0].Name)
+	assert.Equal(t, progrep.OperationStatusPending, activeOps[0].Status)
+}
+
+func TestAI_StartStage_FiltersNonResourceOps(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 64)
+	reporter := NewLegacyProgressReporter(ch)
+
+	ops := []*Operation{
+		{
+			Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+			Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+		},
+		{
+			Type: OperationTypeNoop, Version: OperationVersionNoop, Category: OperationCategoryMeta,
+			Config: &OperationConfigNoop{OpID: "stage/start"},
+		},
+	}
+	p := buildTestPlan(ops, nil)
+	reporter.startStage(p, map[string]string{ops[0].ID(): "default"})
+
+	reports := drainChannel(ch)
+	require.NotEmpty(t, reports)
+
+	last := reports[len(reports)-1]
+	require.Len(t, last.StageReports, 1)
+
+	assert.Len(t, last.StageReports[0].Operations, 1)
+	assert.Equal(t, "cm1", last.StageReports[0].Operations[0].Name)
+}
+
+func TestAI_ReportStatus_WaitingForPopulation(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 64)
+	reporter := NewLegacyProgressReporter(ch)
+
+	opA := &Operation{
+		Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+		Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+	}
+	opB := &Operation{
+		Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+		Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("svc1", "", gvkService)},
+	}
+
+	p := buildTestPlan([]*Operation{opA, opB}, map[int][]int{1: {0}})
+
+	resolvedNS := map[string]string{
+		opA.ID(): "default",
+		opB.ID(): "default",
+	}
+	reporter.startStage(p, resolvedNS)
+
+	reports := drainChannel(ch)
+	require.NotEmpty(t, reports)
+
+	last := reports[len(reports)-1]
+	activeOps := last.StageReports[0].Operations
+
+	var opBReport *progrep.Operation
+	for i := range activeOps {
+		if activeOps[i].Name == "svc1" {
+			opBReport = &activeOps[i]
+		}
+	}
+
+	require.NotNil(t, opBReport, "expected svc1 in operations")
+	require.Len(t, opBReport.WaitingFor, 1, "svc1 should be waiting for cm1")
+	assert.Equal(t, "cm1", opBReport.WaitingFor[0].Name)
+
+	reporter.ReportStatus(opA.ID(), progrep.OperationStatusCompleted)
+	reports = drainChannel(ch)
+	require.NotEmpty(t, reports)
+
+	last = reports[len(reports)-1]
+	activeOps = last.StageReports[0].Operations
+
+	opBReport = nil
+	for i := range activeOps {
+		if activeOps[i].Name == "svc1" {
+			opBReport = &activeOps[i]
+		}
+	}
+
+	require.NotNil(t, opBReport)
+	assert.Empty(t, opBReport.WaitingFor, "svc1 should no longer be waiting after cm1 completed")
+}
+
+func TestAI_SendNonBlocking_DropsWhenFull(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 1)
+
+	ch <- progrep.ProgressReport{}
+
+	sendNonBlocking(ch, progrep.ProgressReport{StageReports: []progrep.StageReport{{}}})
+
+	assert.Len(t, ch, 1)
+
+	msg := <-ch
+	assert.Empty(t, msg.StageReports, "expected the original empty report, not the dropped one")
+}
+
+func TestAI_Stop_SendsFinalReport(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 64)
+	reporter := NewLegacyProgressReporter(ch)
+
+	ops := []*Operation{
+		{
+			Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+			Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+		},
+	}
+	p := buildTestPlan(ops, nil)
+	reporter.startStage(p, map[string]string{ops[0].ID(): "default"})
+	reporter.ReportStatus(ops[0].ID(), progrep.OperationStatusCompleted)
+
+	drainChannel(ch)
+
+	ctx := context.Background()
+	reporter.Stop(ctx)
+
+	reports := drainChannel(ch)
+	require.Len(t, reports, 1, "Stop should send exactly one final report")
+
+	finalOps := reports[0].StageReports[0].Operations
+	require.Len(t, finalOps, 1)
+	assert.Equal(t, progrep.OperationStatusCompleted, finalOps[0].Status)
+}
+
+func TestAI_Stop_SkipsOnCanceledContext(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 1)
+	ch <- progrep.ProgressReport{}
+
+	reporter := NewLegacyProgressReporter(ch)
+
+	ops := []*Operation{
+		{
+			Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+			Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+		},
+	}
+	p := buildTestPlan(ops, nil)
+	reporter.startStage(p, map[string]string{ops[0].ID(): "default"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	reporter.Stop(ctx)
+
+	assert.Len(t, ch, 1)
+}
+
+func TestAI_MapOperationType(t *testing.T) {
+	tests := []struct {
+		input    OperationType
+		expected progrep.OperationType
+	}{
+		{OperationTypeCreate, progrep.OperationTypeCreate},
+		{OperationTypeUpdate, progrep.OperationTypeUpdate},
+		{OperationTypeDelete, progrep.OperationTypeDelete},
+		{OperationTypeApply, progrep.OperationTypeApply},
+		{OperationTypeRecreate, progrep.OperationTypeRecreate},
+		{OperationTypeTrackReadiness, progrep.OperationTypeTrackReadiness},
+		{OperationTypeTrackPresence, progrep.OperationTypeTrackPresence},
+		{OperationTypeTrackAbsence, progrep.OperationTypeTrackAbsence},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			assert.Equal(t, tt.expected, mapOperationType(tt.input))
+		})
+	}
+}
+
+func TestAI_MapOperationType_PanicsOnUnknown(t *testing.T) {
+	assert.Panics(t, func() {
+		mapOperationType("unknown-type")
+	})
+}
+
+func TestAI_MapOperationStatus(t *testing.T) {
+	tests := []struct {
+		input    OperationStatus
+		expected progrep.OperationStatus
+	}{
+		{OperationStatusUnknown, progrep.OperationStatusPending},
+		{OperationStatusPending, progrep.OperationStatusProgressing},
+		{OperationStatusCompleted, progrep.OperationStatusCompleted},
+		{OperationStatusFailed, progrep.OperationStatusFailed},
+	}
+
+	for _, tt := range tests {
+		name := string(tt.input)
+		if name == "" {
+			name = "unknown"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, mapOperationStatus(tt.input))
+		})
+	}
+}
+
+func TestAI_MapOperationStatus_DefaultCase(t *testing.T) {
+	assert.Equal(t, progrep.OperationStatusPending, mapOperationStatus("some-unexpected-status"))
+}
+
+func TestAI_ResolveNamespace(t *testing.T) {
+	mapper := newFakeRESTMapper()
+	releaseNS := "release-ns"
+
+	tests := []struct {
+		name     string
+		gvk      schema.GroupVersionKind
+		ns       string
+		expected string
+	}{
+		{
+			name:     "namespaced with explicit namespace",
+			gvk:      gvkConfigMap,
+			ns:       "custom-ns",
+			expected: "custom-ns",
+		},
+		{
+			name:     "namespaced with empty namespace falls back to releaseNamespace",
+			gvk:      gvkConfigMap,
+			ns:       "",
+			expected: releaseNS,
+		},
+		{
+			name:     "cluster-scoped returns empty",
+			gvk:      gvkNamespace,
+			ns:       "",
+			expected: "",
+		},
+		{
+			name:     "cluster-scoped ignores explicit namespace",
+			gvk:      gvkNamespace,
+			ns:       "should-be-ignored",
+			expected: "",
+		},
+		{
+			name:     "unknown GVK with namespace uses as-is",
+			gvk:      gvkCRD,
+			ns:       "crd-ns",
+			expected: "crd-ns",
+		},
+		{
+			name:     "unknown GVK without namespace falls back to releaseNamespace",
+			gvk:      gvkCRD,
+			ns:       "",
+			expected: releaseNS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveNamespace(tt.gvk, tt.ns, releaseNS, mapper)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestAI_ExtractObjectRef(t *testing.T) {
+	resolvedNS := map[string]string{}
+
+	tests := []struct {
+		name     string
+		op       *Operation
+		wantName string
+		wantGVK  schema.GroupVersionKind
+	}{
+		{
+			name: "Create",
+			op: &Operation{
+				Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+				Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+			},
+			wantName: "cm1",
+			wantGVK:  gvkConfigMap,
+		},
+		{
+			name: "Update",
+			op: &Operation{
+				Type: OperationTypeUpdate, Version: OperationVersionUpdate, Category: OperationCategoryResource,
+				Config: &OperationConfigUpdate{ResourceSpec: makeResourceSpec("cm2", "", gvkConfigMap)},
+			},
+			wantName: "cm2",
+			wantGVK:  gvkConfigMap,
+		},
+		{
+			name: "Apply",
+			op: &Operation{
+				Type: OperationTypeApply, Version: OperationVersionApply, Category: OperationCategoryResource,
+				Config: &OperationConfigApply{ResourceSpec: makeResourceSpec("svc1", "", gvkService)},
+			},
+			wantName: "svc1",
+			wantGVK:  gvkService,
+		},
+		{
+			name: "Recreate",
+			op: &Operation{
+				Type: OperationTypeRecreate, Version: OperationVersionRecreate, Category: OperationCategoryResource,
+				Config: &OperationConfigRecreate{ResourceSpec: makeResourceSpec("dep1", "", gvkDeployment)},
+			},
+			wantName: "dep1",
+			wantGVK:  gvkDeployment,
+		},
+		{
+			name: "Delete",
+			op: &Operation{
+				Type: OperationTypeDelete, Version: OperationVersionDelete, Category: OperationCategoryResource,
+				Config: &OperationConfigDelete{ResourceMeta: makeResourceMeta("cm3", "", gvkConfigMap)},
+			},
+			wantName: "cm3",
+			wantGVK:  gvkConfigMap,
+		},
+		{
+			name: "TrackReadiness",
+			op: &Operation{
+				Type: OperationTypeTrackReadiness, Version: OperationVersionTrackReadiness, Category: OperationCategoryTrack,
+				Config: &OperationConfigTrackReadiness{ResourceMeta: makeResourceMeta("dep2", "", gvkDeployment)},
+			},
+			wantName: "dep2",
+			wantGVK:  gvkDeployment,
+		},
+		{
+			name: "TrackPresence",
+			op: &Operation{
+				Type: OperationTypeTrackPresence, Version: OperationVersionTrackPresence, Category: OperationCategoryTrack,
+				Config: &OperationConfigTrackPresence{ResourceMeta: makeResourceMeta("svc2", "", gvkService)},
+			},
+			wantName: "svc2",
+			wantGVK:  gvkService,
+		},
+		{
+			name: "TrackAbsence",
+			op: &Operation{
+				Type: OperationTypeTrackAbsence, Version: OperationVersionTrackAbsence, Category: OperationCategoryTrack,
+				Config: &OperationConfigTrackAbsence{ResourceMeta: makeResourceMeta("cm4", "", gvkConfigMap)},
+			},
+			wantName: "cm4",
+			wantGVK:  gvkConfigMap,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolvedNS[tt.op.ID()] = "test-ns"
+
+			ref := extractObjectRef(tt.op, resolvedNS)
+
+			assert.Equal(t, tt.wantName, ref.Name)
+			assert.Equal(t, tt.wantGVK, ref.GroupVersionKind)
+			assert.Equal(t, "test-ns", ref.Namespace)
+		})
+	}
+}
+
+func TestAI_ExtractObjectRef_PanicsOnUnexpectedConfig(t *testing.T) {
+	op := &Operation{
+		Type:     OperationTypeNoop,
+		Version:  OperationVersionNoop,
+		Category: OperationCategoryMeta,
+		Config:   &OperationConfigNoop{OpID: "test"},
+	}
+
+	assert.Panics(t, func() {
+		extractObjectRef(op, map[string]string{})
+	})
+}
+
+func TestAI_BuildResolvedNamespaces(t *testing.T) {
+	mapper := newFakeRESTMapper()
+	releaseNS := "release-ns"
+
+	opNamespaced := &Operation{
+		Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+		Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+	}
+	opNamespacedExplicit := &Operation{
+		Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+		Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm2", "custom-ns", gvkConfigMap)},
+	}
+	opClusterScoped := &Operation{
+		Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+		Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("my-ns", "", gvkNamespace)},
+	}
+	opMeta := &Operation{
+		Type: OperationTypeNoop, Version: OperationVersionNoop, Category: OperationCategoryMeta,
+		Config: &OperationConfigNoop{OpID: "stage/start"},
+	}
+	opTrack := &Operation{
+		Type: OperationTypeTrackReadiness, Version: OperationVersionTrackReadiness, Category: OperationCategoryTrack,
+		Config: &OperationConfigTrackReadiness{ResourceMeta: makeResourceMeta("dep1", "", gvkDeployment)},
+	}
+
+	p := buildTestPlan([]*Operation{opNamespaced, opNamespacedExplicit, opClusterScoped, opMeta, opTrack}, nil)
+
+	resolved := buildResolvedNamespaces(p, releaseNS, mapper)
+
+	assert.Equal(t, releaseNS, resolved[opNamespaced.ID()])
+	assert.Equal(t, "custom-ns", resolved[opNamespacedExplicit.ID()])
+	assert.Equal(t, "", resolved[opClusterScoped.ID()])
+
+	_, metaPresent := resolved[opMeta.ID()]
+	assert.False(t, metaPresent, "meta operations should not appear in resolved namespaces")
+
+	assert.Equal(t, releaseNS, resolved[opTrack.ID()])
+}
+
+func TestAI_ReportOperationStatus_SetsStatusWithoutReporter(t *testing.T) {
+	op := &Operation{
+		Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+		Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+	}
+
+	reportOperationStatus(op, OperationStatusCompleted, nil)
+	assert.Equal(t, OperationStatusCompleted, op.Status)
+}
+
+func TestAI_ReportOperationStatus_SetsStatusAndReports(t *testing.T) {
+	ch := make(chan progrep.ProgressReport, 64)
+	reporter := NewLegacyProgressReporter(ch)
+
+	op := &Operation{
+		Type: OperationTypeCreate, Version: OperationVersionCreate, Category: OperationCategoryResource,
+		Config: &OperationConfigCreate{ResourceSpec: makeResourceSpec("cm1", "", gvkConfigMap)},
+	}
+	p := buildTestPlan([]*Operation{op}, nil)
+	reporter.startStage(p, map[string]string{op.ID(): "default"})
+	drainChannel(ch)
+
+	reportOperationStatus(op, OperationStatusPending, reporter)
+
+	assert.Equal(t, OperationStatusPending, op.Status)
+
+	reports := drainChannel(ch)
+	require.NotEmpty(t, reports)
+
+	activeOps := reports[len(reports)-1].StageReports[0].Operations
+	require.Len(t, activeOps, 1)
+	assert.Equal(t, progrep.OperationStatusProgressing, activeOps[0].Status)
+}

--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -179,7 +179,8 @@ func printReport(ctx context.Context, report *releaseReportV3) {
 type runFailureInstallPlanOptions struct {
 	common.TrackingOptions
 
-	NetworkParallelism int
+	LegacyProgressReporter *plan.LegacyProgressReporter
+	NetworkParallelism     int
 }
 
 type runFailurePlanResult struct {
@@ -227,8 +228,9 @@ func runFailurePlan(
 	log.Default.Debug(ctx, "Execute failure plan")
 
 	if err := plan.ExecutePlan(ctx, releaseNamespace, failurePlan, taskStore, logStore, informerFactory, history, clientFactory, plan.ExecutePlanOptions{
-		TrackingOptions:    opts.TrackingOptions,
-		NetworkParallelism: opts.NetworkParallelism,
+		LegacyProgressReporter: opts.LegacyProgressReporter,
+		TrackingOptions:        opts.TrackingOptions,
+		NetworkParallelism:     opts.NetworkParallelism,
 	}); err != nil {
 		critErrs.Add(fmt.Errorf("execute failure plan: %w", err))
 	}

--- a/pkg/legacy/progrep/progress_report.go
+++ b/pkg/legacy/progrep/progress_report.go
@@ -1,0 +1,52 @@
+package progrep
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// ProgressReport contains stage reports ordered chronologically; the last element is the
+// currently active stage.
+type ProgressReport struct {
+	StageReports []StageReport
+}
+
+// StageReport contains ALL operations in the plan -- from the very first report, every
+// operation is present (initially as Pending).
+type StageReport struct {
+	Operations []Operation
+}
+
+type Operation struct {
+	ObjectRef
+
+	Type       OperationType
+	Status     OperationStatus
+	WaitingFor []ObjectRef
+}
+
+type OperationType string
+
+const (
+	OperationTypeCreate         OperationType = "Create"
+	OperationTypeUpdate         OperationType = "Update"
+	OperationTypeDelete         OperationType = "Delete"
+	OperationTypeApply          OperationType = "Apply"
+	OperationTypeRecreate       OperationType = "Recreate"
+	OperationTypeTrackReadiness OperationType = "TrackReadiness"
+	OperationTypeTrackPresence  OperationType = "TrackPresence"
+	OperationTypeTrackAbsence   OperationType = "TrackAbsence"
+)
+
+type OperationStatus string
+
+const (
+	OperationStatusPending     OperationStatus = "Pending"
+	OperationStatusProgressing OperationStatus = "Progressing"
+	OperationStatusCompleted   OperationStatus = "Completed"
+	OperationStatusFailed      OperationStatus = "Failed"
+)
+
+type ObjectRef struct {
+	schema.GroupVersionKind
+
+	Name      string
+	Namespace string
+}


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds a legacy progress reporting option for ReleaseInstall and ReleaseUninstall operations, enabling backward compatibility with werf integrations. It introduces a buffered channel-based reporting mechanism that provides progress snapshots during deployment operations. The implementation includes new progress report types, a reporter component, and integration into the plan execution pipeline.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds LegacyProgressReportCh option to ReleaseInstallOptions and ReleaseUninstallOptions in pkg/action/release_install.go and release_uninstall.go.</li>

<li>Introduces new pkg/legacy/progrep package with ProgressReport, StageReport, Operation types and constants.</li>

<li>Implements LegacyProgressReporter in internal/plan/legacy_progress_reporter.go for managing progress state and reporting.</li>

<li>Modifies plan.ExecutePlan to accept and initialize LegacyProgressReporter, updating operation status reporting in plan_execute.go.</li>

<li>Adds comprehensive tests in internal/plan/legacy_progress_reporter_ai_test.go and helpers in helpers_ai_test.go.</li>

</ul>
</details>

</div>