### PR TITLE
feat: `--set-root-json` flag

### DIFF
--- a/cmd/nelm/common_flags.go
+++ b/cmd/nelm/common_flags.go
@@ -364,6 +364,14 @@ func AddValuesFlags(cmd *cobra.Command, cfg *common.ValuesOptions) error {
 		return fmt.Errorf("add flag: %w", err)
 	}
 
+	if err := cli.AddFlag(cmd, &cfg.RootSetJSON, "set-root-json", []string{}, "Set new keys in the global context ($), where the key is the value path and the value is JSON. This is meant to be generated inside the program, so use --set-json instead, unless you know what you are doing", cli.AddFlagOptions{
+		GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
+		Group:                valuesFlagGroup,
+		NoSplitOnCommas:      true,
+	}); err != nil {
+		return fmt.Errorf("add flag: %w", err)
+	}
+
 	if err := cli.AddFlag(cmd, &cfg.RuntimeSetJSON, "set-runtime-json", []string{}, "Set new keys in $.Runtime, where the key is the value path and the value is JSON. This is meant to be generated inside the program, so use --set-json instead, unless you know what you are doing", cli.AddFlagOptions{
 		GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
 		Group:                valuesFlagGroup,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -218,6 +218,10 @@ nelm release install [options...] -n namespace -r release [chart-dir]
 
   Set new values, where the key is the value path and the value is the value\. The value will always become a literal string\. Vars: \$NELM\_SET\_LITERAL, \$NELM\_RELEASE\_INSTALL\_SET\_LITERAL
 
+- `--set-root-json` (default: `[]`)
+
+  Set new keys in the global context \(\$\), where the key is the value path and the value is JSON\. This is meant to be generated inside the program, so use \-\-set\-json instead, unless you know what you are doing\. Vars: \$NELM\_SET\_ROOT\_JSON, \$NELM\_RELEASE\_INSTALL\_SET\_ROOT\_JSON
+
 - `--set-runtime-json` (default: `[]`)
 
   Set new keys in \$\.Runtime, where the key is the value path and the value is JSON\. This is meant to be generated inside the program, so use \-\-set\-json instead, unless you know what you are doing\. Vars: \$NELM\_SET\_RUNTIME\_JSON, \$NELM\_RELEASE\_INSTALL\_SET\_RUNTIME\_JSON
@@ -858,6 +862,10 @@ nelm release plan install [options...] -n namespace -r release [chart-dir]
 - `--set-literal` (default: `[]`)
 
   Set new values, where the key is the value path and the value is the value\. The value will always become a literal string\. Vars: \$NELM\_SET\_LITERAL, \$NELM\_RELEASE\_PLAN\_INSTALL\_SET\_LITERAL
+
+- `--set-root-json` (default: `[]`)
+
+  Set new keys in the global context \(\$\), where the key is the value path and the value is JSON\. This is meant to be generated inside the program, so use \-\-set\-json instead, unless you know what you are doing\. Vars: \$NELM\_SET\_ROOT\_JSON, \$NELM\_RELEASE\_PLAN\_INSTALL\_SET\_ROOT\_JSON
 
 - `--set-runtime-json` (default: `[]`)
 
@@ -1840,6 +1848,10 @@ nelm chart lint [options...] [chart-dir]
 
   Set new values, where the key is the value path and the value is the value\. The value will always become a literal string\. Vars: \$NELM\_SET\_LITERAL, \$NELM\_CHART\_LINT\_SET\_LITERAL
 
+- `--set-root-json` (default: `[]`)
+
+  Set new keys in the global context \(\$\), where the key is the value path and the value is JSON\. This is meant to be generated inside the program, so use \-\-set\-json instead, unless you know what you are doing\. Vars: \$NELM\_SET\_ROOT\_JSON, \$NELM\_CHART\_LINT\_SET\_ROOT\_JSON
+
 - `--set-runtime-json` (default: `[]`)
 
   Set new keys in \$\.Runtime, where the key is the value path and the value is JSON\. This is meant to be generated inside the program, so use \-\-set\-json instead, unless you know what you are doing\. Vars: \$NELM\_SET\_RUNTIME\_JSON, \$NELM\_CHART\_LINT\_SET\_RUNTIME\_JSON
@@ -2176,6 +2188,10 @@ nelm chart render [options...] [chart-dir]
 - `--set-literal` (default: `[]`)
 
   Set new values, where the key is the value path and the value is the value\. The value will always become a literal string\. Vars: \$NELM\_SET\_LITERAL, \$NELM\_CHART\_RENDER\_SET\_LITERAL
+
+- `--set-root-json` (default: `[]`)
+
+  Set new keys in the global context \(\$\), where the key is the value path and the value is JSON\. This is meant to be generated inside the program, so use \-\-set\-json instead, unless you know what you are doing\. Vars: \$NELM\_SET\_ROOT\_JSON, \$NELM\_CHART\_RENDER\_SET\_ROOT\_JSON
 
 - `--set-runtime-json` (default: `[]`)
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/wI2L/jsondiff v0.5.0
-	github.com/werf/3p-helm v0.0.0-20260206103658-171c7659858a
+	github.com/werf/3p-helm v0.0.0-20260211143448-0b619e3cc3bf
 	github.com/werf/common-go v0.0.0-20251113140850-a1a98e909e9b
 	github.com/werf/kubedog v0.13.1-0.20260115171811-304218f24308
 	github.com/werf/lockgate v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -429,6 +429,8 @@ github.com/werf/3p-helm v0.0.0-20260204140535-11a50c572ad8 h1:PrrWCukmr1enIzLoKR
 github.com/werf/3p-helm v0.0.0-20260204140535-11a50c572ad8/go.mod h1:UAmQvGZhiUULXQpigm1yqcp57s097kpAHz2EvFtKCSk=
 github.com/werf/3p-helm v0.0.0-20260206103658-171c7659858a h1:LtJjZfpvNKyh48On7h7SnGV6nbkzfR18oMcWLJAKm8o=
 github.com/werf/3p-helm v0.0.0-20260206103658-171c7659858a/go.mod h1:UAmQvGZhiUULXQpigm1yqcp57s097kpAHz2EvFtKCSk=
+github.com/werf/3p-helm v0.0.0-20260211143448-0b619e3cc3bf h1:lWl6myftkC7mIRJ15LvUPNVHIzi7CIVHZhyhsNqD5mc=
+github.com/werf/3p-helm v0.0.0-20260211143448-0b619e3cc3bf/go.mod h1:UAmQvGZhiUULXQpigm1yqcp57s097kpAHz2EvFtKCSk=
 github.com/werf/common-go v0.0.0-20251113140850-a1a98e909e9b h1:58850oFrnw5Jy5YaB8QifXz75qpGotfx6qqZ9Q2my1A=
 github.com/werf/common-go v0.0.0-20251113140850-a1a98e909e9b/go.mod h1:MXS0JR9zut+oR9oEM8PEkdXXoEbKDILTmWopt0z1eZs=
 github.com/werf/kubedog v0.13.1-0.20260115171811-304218f24308 h1:ee55f/lNya8V9jCBsQWDhvOw6y1fB0uysop8te9aUcM=

--- a/pkg/common/options.go
+++ b/pkg/common/options.go
@@ -120,9 +120,14 @@ type ValuesOptions struct {
 	// DefaultValuesDisable, when true, ignores the values.yaml file from the top-level chart.
 	// Useful when you want complete control over values without chart defaults.
 	DefaultValuesDisable bool
+	// RootSetJSON is a list of key-value pairs in "key=json" format to set
+	// arbitrary things in the global root context ("$"). This is meant to be
+	// generated programmatically. Do not use it unless you know what you are doing.
+	RootSetJSON []string
 	// RuntimeSetJSON is a list of key-value pairs in "key=json" format to set in $.Runtime.
 	// This is meant to be generated programmatically. Users should prefer ValuesSetJSON.
 	// Example: ["runtime.env=dev", "runtime.timestamp=1234567890"]
+	// TODO(v2): get rid of it
 	RuntimeSetJSON []string
 	// ValuesFiles is a list of paths to additional values files to merge with chart values.
 	// Files are merged in order, with later files overriding earlier ones.


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request implements a new `--set-root-json` command-line flag that allows setting arbitrary keys in the global root context using JSON values, intended for programmatic use rather than direct user input. It updates the flag handling logic, adds a new option field to the values configuration, modifies the chart rendering process to incorporate the new root context, and updates a dependency version.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds `--set-root-json` flag in cmd/nelm/common_flags.go to enable programmatic setting of global context keys with JSON values.</li>

<li>Introduces RootSetJSON field in pkg/common/options.go ValuesOptions struct to store the JSON key-value pairs.</li>

<li>Modifies chart rendering logic in internal/chart/chart_render.go to build and integrate default root context from JSON sets into the rendering process.</li>

<li>Refactors buildRuntime function in internal/chart/chart_render.go to buildContextFromJSONSets for reusable context building.</li>

<li>Updates github.com/werf/3p-helm dependency in go.mod and adds checksums in go.sum.</li>

</ul>
</details>

</div>