### PR TITLE
fix: print engine.Render() result on debug level

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -53,7 +53,6 @@ jobs:
     uses: ./.github/workflows/_test_unit.yml
     with:
       forceSkip: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.src_changed == 'false' }}
-      excludePackages: internal/helm
 
   build:
     needs: detect-changes


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Replaced a single TraceStruct log for rendered templates with a loop that selectively logs individual file contents at Debug level.</li>
<li>Added conditions to skip logging files that start with '_', end with NotesFileSuffix, or are empty after trimming.</li>
<li>Changed logging from tracing the entire renderedTemplates struct to detailed logging of qualifying template contents.</li>
</ul></div>