### PR TITLE
fix: retry also on conversion webhooks unavailability

### DIFF
--- a/pkg/kube/error.go
+++ b/pkg/kube/error.go
@@ -21,5 +21,7 @@ func IsNotFoundErr(err error) bool {
 }
 
 func IsWebhookErr(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "failed calling webhook")
+	return err != nil &&
+		(strings.Contains(err.Error(), "Internal error occurred: failed calling webhook") ||
+			strings.Contains(err.Error(), "Internal error occurred: conversion webhook for"))
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

