### PR TITLE
Pin unpinned-action references across 10 workflows

### DIFF
--- a/.github/workflows/_coverage_report.yml
+++ b/.github/workflows/_coverage_report.yml
@@ -16,15 +16,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: coverage
 
       - name: Format and upload coverage report
-        uses: qltysh/qlty-action/coverage@v2
+        uses: qltysh/qlty-action/coverage@fd52dc852530a708d68c3b7342f8d33d1df4cd55
         with:
           token: ${{secrets.QLTY_COVERAGE_TOKEN}}
           files: coverage/*.out,coverage/coverage-*/*.out

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -21,16 +21,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           cache: false
           go-version-file: go.mod
 
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_test_unit.yml
+++ b/.github/workflows/_test_unit.yml
@@ -30,15 +30,15 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/generate_main.yml
+++ b/.github/workflows/generate_main.yml
@@ -17,18 +17,18 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           cache: false
           go-version-file: go.mod
 
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
         with:
           repo-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 

--- a/.github/workflows/issues_delayed-auto-close.yml
+++ b/.github/workflows/issues_delayed-auto-close.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: tiangolo/issue-manager@0.6.0
+      - uses: tiangolo/issue-manager@2fb3484ec9279485df8659e8ec73de262431737d
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >

--- a/.github/workflows/release_release-please.yml
+++ b/.github/workflows/release_release-please.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Release
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:
           target-branch: ${{github.ref_name}}
           release-type: go

--- a/.github/workflows/release_trdl-publish.yml
+++ b/.github/workflows/release_trdl-publish.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Notify
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.LOOP_NOTIFICATION_WEBHOOK }}
           MATTERMOST_CHANNEL: ${{ vars.LOOP_NOTIFICATION_CHANNEL }}
@@ -27,7 +27,7 @@ jobs:
             ${{ vars.LOOP_NOTIFICATION_GROUP }} [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) nelm task sign pls
 
       - name: Publish with retry
-        uses: werf/trdl-vault-actions/publish@main
+        uses: werf/trdl-vault-actions/publish@92e6e6d13b6927c9fa0ad1dfa90fdded4c474581
         with:
           vault-addr: ${{ secrets.TRDL_VAULT_ADDR }}
           project-name: nelm
@@ -41,7 +41,7 @@ jobs:
       - publish
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/release_trdl-release.yml
+++ b/.github/workflows/release_trdl-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Notify
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.LOOP_NOTIFICATION_WEBHOOK }}
           MATTERMOST_CHANNEL: ${{ vars.LOOP_NOTIFICATION_CHANNEL }}
@@ -21,7 +21,7 @@ jobs:
             ${{ vars.LOOP_NOTIFICATION_GROUP }} [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) nelm task sign pls
 
       - name: Release with retry
-        uses: werf/trdl-vault-actions/release@main
+        uses: werf/trdl-vault-actions/release@92e6e6d13b6927c9fa0ad1dfa90fdded4c474581
         with:
           vault-addr: ${{ secrets.TRDL_VAULT_ADDR }}
           project-name: nelm
@@ -31,7 +31,7 @@ jobs:
           vault-secret-id: ${{ secrets.TRDL_VAULT_SECRET_ID }}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/tag_auto-create.yml
+++ b/.github/workflows/tag_auto-create.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -23,11 +23,11 @@ jobs:
       lint_changed: ${{ steps.changed-files.outputs.lint_any_changed }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Detect file groups
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
         with:
           files_yaml: |
             src:
@@ -66,17 +66,17 @@ jobs:
           sudo apt install -y gcc-aarch64-linux-gnu file
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           cache: false
           go-version-file: go.mod
 
       - name: Cache Go modules and build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ~/.cache/go-build
@@ -86,7 +86,7 @@ jobs:
             ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/_coverage_report.yml`

- 🟠 MED `qltysh/qlty-action/coverage` (job `_`)
- ⚪ LOW `actions/checkout` (job `_`)
- ⚪ LOW `actions/download-artifact` (job `_`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/_coverage_report.yml
+++ b/.github/workflows/_coverage_report.yml
@@ -16,15 +16,15 @@
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: coverage
 
       - name: Format and upload coverage report
-        uses: qltysh/qlty-action/coverage@v2
+        uses: qltysh/qlty-action/coverage@fd52dc852530a708d68c3b7342f8d33d1df4cd55
         with:
           token: ${{secrets.QLTY_COVERAGE_TOKEN}}
           files: coverage/*.out,coverage/coverage-*/*.out
```

</details>

### `.github/workflows/_lint.yml`

- 🟠 MED `go-task/setup-task` (job `_`)
- ⚪ LOW `actions/checkout` (job `_`)
- ⚪ LOW `actions/setup-go` (job `_`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -21,16 +21,16 @@
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           cache: false
           go-version-file: go.mod
 
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
```

</details>

### `.github/workflows/_test_unit.yml`

- 🟠 MED `go-task/setup-task` (job `_`)
- ⚪ LOW `actions/checkout` (job `_`)
- ⚪ LOW `actions/setup-go` (job `_`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/_test_unit.yml
+++ b/.github/workflows/_test_unit.yml
@@ -30,15 +30,15 @@
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
```

</details>

### `.github/workflows/generate_main.yml`

- 🟠 MED `go-task/setup-task` (job `generate-reference`)
- ⚪ LOW `actions/checkout` (job `generate-reference`)
- ⚪ LOW `actions/setup-go` (job `generate-reference`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/generate_main.yml
+++ b/.github/workflows/generate_main.yml
@@ -17,18 +17,18 @@
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           cache: false
           go-version-file: go.mod
 
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
         with:
           repo-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
```

</details>

### `.github/workflows/issues_delayed-auto-close.yml`

- 🟠 MED `tiangolo/issue-manager` (job `manage`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/issues_delayed-auto-close.yml
+++ b/.github/workflows/issues_delayed-auto-close.yml
@@ -24,7 +24,7 @@
       issues: write
       pull-requests: write
     steps:
-      - uses: tiangolo/issue-manager@0.6.0
+      - uses: tiangolo/issue-manager@2fb3484ec9279485df8659e8ec73de262431737d
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >
```

</details>

### `.github/workflows/release_release-please.yml`

- 🟠 MED `googleapis/release-please-action` (job `release-please`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release_release-please.yml
+++ b/.github/workflows/release_release-please.yml
@@ -21,7 +21,7 @@
     steps:
       - name: Release
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:
           target-branch: ${{github.ref_name}}
           release-type: go
```

</details>

### `.github/workflows/release_trdl-publish.yml`

- 🟠 MED `mattermost/action-mattermost-notify` (job `publish`)
- 🟠 MED `werf/trdl-vault-actions/publish` (job `publish`)
- ⚪ LOW `actions/checkout` (job `update_release`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release_trdl-publish.yml
+++ b/.github/workflows/release_trdl-publish.yml
@@ -19,7 +19,7 @@
     runs-on: ubuntu-22.04
     steps:
       - name: Notify
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.LOOP_NOTIFICATION_WEBHOOK }}
           MATTERMOST_CHANNEL: ${{ vars.LOOP_NOTIFICATION_CHANNEL }}
@@ -27,7 +27,7 @@
             ${{ vars.LOOP_NOTIFICATION_GROUP }} [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) nelm task sign pls
 
       - name: Publish with retry
-        uses: werf/trdl-vault-actions/publish@main
+        uses: werf/trdl-vault-actions/publish@92e6e6d13b6927c9fa0ad1dfa90fdded4c474581
         with:
           vault-addr: ${{ secrets.TRDL_VAULT_ADDR }}
           project-name: nelm
@@ -41,7 +41,7 @@
       - publish
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true
```

</details>

### `.github/workflows/release_trdl-release.yml`

- 🟠 MED `mattermost/action-mattermost-notify` (job `release`)
- 🟠 MED `werf/trdl-vault-actions/release` (job `release`)
- ⚪ LOW `actions/checkout` (job `release`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release_trdl-release.yml
+++ b/.github/workflows/release_trdl-release.yml
@@ -13,7 +13,7 @@
     runs-on: ubuntu-22.04
     steps:
       - name: Notify
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.LOOP_NOTIFICATION_WEBHOOK }}
           MATTERMOST_CHANNEL: ${{ vars.LOOP_NOTIFICATION_CHANNEL }}
@@ -21,7 +21,7 @@
             ${{ vars.LOOP_NOTIFICATION_GROUP }} [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) nelm task sign pls
 
       - name: Release with retry
-        uses: werf/trdl-vault-actions/release@main
+        uses: werf/trdl-vault-actions/release@92e6e6d13b6927c9fa0ad1dfa90fdded4c474581
         with:
           vault-addr: ${{ secrets.TRDL_VAULT_ADDR }}
           project-name: nelm
@@ -31,7 +31,7 @@
           vault-secret-id: ${{ secrets.TRDL_VAULT_SECRET_ID }}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true
```

</details>

### `.github/workflows/tag_auto-create.yml`

- ⚪ LOW `actions/checkout` (job `release`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/tag_auto-create.yml
+++ b/.github/workflows/tag_auto-create.yml
@@ -16,7 +16,7 @@
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true
```

</details>

### `.github/workflows/test_pr.yml`

- 🟠 MED `tj-actions/changed-files` (job `detect-changes`)
- 🟠 MED `go-task/setup-task` (job `build`)
- ⚪ LOW `actions/checkout` (job `detect-changes`)
- ⚪ LOW `actions/checkout` (job `build`)
- ⚪ LOW `actions/setup-go` (job `build`)
- ⚪ LOW `actions/cache` (job `build`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -23,11 +23,11 @@
       lint_changed: ${{ steps.changed-files.outputs.lint_any_changed }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Detect file groups
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
         with:
           files_yaml: |
             src:
@@ -66,17 +66,17 @@
           sudo apt install -y gcc-aarch64-linux-gnu file
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           cache: false
           go-version-file: go.mod
 
       - name: Cache Go modules and build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ~/.cache/go-build
@@ -86,7 +86,7 @@
             ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
 
... (6 more diff lines — see Files changed)
```

</details>

---

This commit is signed off per the repository's DCO (Developer Certificate of Origin) policy.

---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

