### PR TITLE
fix: HelmCompatibleTracking mode should allow annotations override

### DIFF
--- a/pkg/resource/spec/patch.go
+++ b/pkg/resource/spec/patch.go
@@ -126,9 +126,16 @@ func (p *LegacyOnlyTrackJobsPatcher) Match(ctx context.Context, info *ResourcePa
 }
 
 func (p *LegacyOnlyTrackJobsPatcher) Patch(ctx context.Context, info *ResourcePatcherResourceInfo) (*unstructured.Unstructured, error) {
+	existing := info.Obj.GetAnnotations()
+
 	annos := map[string]string{}
-	annos["werf.io/fail-mode"] = string(multitrack.IgnoreAndContinueDeployProcess)
-	annos["werf.io/track-termination-mode"] = string(multitrack.NonBlocking)
+	if !lo.HasKey(existing, common.AnnotationKeyHumanFailMode) {
+		annos[common.AnnotationKeyHumanFailMode] = string(multitrack.IgnoreAndContinueDeployProcess)
+	}
+
+	if !lo.HasKey(existing, common.AnnotationKeyHumanTrackTerminationMode) {
+		annos[common.AnnotationKeyHumanTrackTerminationMode] = string(multitrack.NonBlocking)
+	}
 
 	setAnnotationsAndLabels(info.Obj, annos, nil)
 

--- a/pkg/resource/spec/patch_ai_test.go
+++ b/pkg/resource/spec/patch_ai_test.go
@@ -1,0 +1,101 @@
+//go:build ai_tests
+
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/werf/kubedog/pkg/trackers/rollout/multitrack"
+	"github.com/werf/nelm/pkg/common"
+	"github.com/werf/nelm/pkg/resource/spec"
+)
+
+func TestAI_LegacyOnlyTrackJobsPatcher_Patch(t *testing.T) {
+	defaultFailMode := string(multitrack.IgnoreAndContinueDeployProcess)
+	defaultTrackTermination := string(multitrack.NonBlocking)
+
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:  "injects both defaults when neither key is set",
+			input: nil,
+			expected: map[string]string{
+				common.AnnotationKeyHumanFailMode:             defaultFailMode,
+				common.AnnotationKeyHumanTrackTerminationMode: defaultTrackTermination,
+			},
+		},
+		{
+			name: "preserves both user-set values",
+			input: map[string]string{
+				common.AnnotationKeyHumanFailMode:             string(multitrack.FailWholeDeployProcessImmediately),
+				common.AnnotationKeyHumanTrackTerminationMode: string(multitrack.WaitUntilResourceReady),
+			},
+			expected: map[string]string{
+				common.AnnotationKeyHumanFailMode:             string(multitrack.FailWholeDeployProcessImmediately),
+				common.AnnotationKeyHumanTrackTerminationMode: string(multitrack.WaitUntilResourceReady),
+			},
+		},
+		{
+			name: "preserves fail-mode override and injects track-termination default",
+			input: map[string]string{
+				common.AnnotationKeyHumanFailMode: string(multitrack.FailWholeDeployProcessImmediately),
+			},
+			expected: map[string]string{
+				common.AnnotationKeyHumanFailMode:             string(multitrack.FailWholeDeployProcessImmediately),
+				common.AnnotationKeyHumanTrackTerminationMode: defaultTrackTermination,
+			},
+		},
+		{
+			name: "preserves track-termination override and injects fail-mode default",
+			input: map[string]string{
+				common.AnnotationKeyHumanTrackTerminationMode: string(multitrack.WaitUntilResourceReady),
+			},
+			expected: map[string]string{
+				common.AnnotationKeyHumanFailMode:             defaultFailMode,
+				common.AnnotationKeyHumanTrackTerminationMode: string(multitrack.WaitUntilResourceReady),
+			},
+		},
+		{
+			name: "treats empty values as user overrides",
+			input: map[string]string{
+				common.AnnotationKeyHumanFailMode:             "",
+				common.AnnotationKeyHumanTrackTerminationMode: "",
+			},
+			expected: map[string]string{
+				common.AnnotationKeyHumanFailMode:             "",
+				common.AnnotationKeyHumanTrackTerminationMode: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+			}}
+			if tt.input != nil {
+				obj.SetAnnotations(tt.input)
+			}
+
+			patcher := spec.NewLegacyOnlyTrackJobsPatcher()
+
+			out, err := patcher.Patch(context.Background(), &spec.ResourcePatcherResourceInfo{Obj: obj})
+			require.NoError(t, err)
+
+			annos := out.GetAnnotations()
+			require.Equal(t, tt.expected[common.AnnotationKeyHumanFailMode], annos[common.AnnotationKeyHumanFailMode])
+			require.Equal(t, tt.expected[common.AnnotationKeyHumanTrackTerminationMode], annos[common.AnnotationKeyHumanTrackTerminationMode])
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

