### PR TITLE
fix: `werf.io/resource-policy` should only respect skip-delete from live

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -377,5 +377,13 @@ func ResolveResourcePolicies(localRes *InstallableResource, liveMeta *spec.Resou
 		return localRes.ResourcePolicies
 	}
 
-	return ResourcePolicies(liveMeta, releaseNamespace)
+	// TODO(major): in the next major keep/skip-delete should also be read/respected only from the manifest, not the cluster.
+	livePolicies := lo.Filter(ResourcePolicies(liveMeta, releaseNamespace), func(p common.ResourcePolicy, _ int) bool {
+		return p == common.ResourcePolicySkipDelete
+	})
+	if len(livePolicies) == 0 {
+		return nil
+	}
+
+	return livePolicies
 }

--- a/pkg/resource/resource_policy_test.go
+++ b/pkg/resource/resource_policy_test.go
@@ -41,9 +41,32 @@ func TestResolveResourcePolicies(t *testing.T) {
 			want:    []common.ResourcePolicy{common.ResourcePolicySkipCreate, common.ResourcePolicySkipUpdate, common.ResourcePolicySkipRecreate},
 		},
 		{
-			name: "live used when chart absent",
+			name: "live skip-update dropped when chart absent",
 			live: map[string]string{"werf.io/resource-policy": "skip-update"},
-			want: []common.ResourcePolicy{common.ResourcePolicySkipUpdate},
+		},
+		{
+			name: "live install skips dropped when chart absent",
+			live: map[string]string{"werf.io/resource-policy": "skip-create,skip-update,skip-recreate"},
+		},
+		{
+			name: "live skip-delete retained when chart absent",
+			live: map[string]string{"werf.io/resource-policy": "skip-delete"},
+			want: []common.ResourcePolicy{common.ResourcePolicySkipDelete},
+		},
+		{
+			name: "live werf.io keep retained as skip-delete when chart absent",
+			live: map[string]string{"werf.io/resource-policy": "keep"},
+			want: []common.ResourcePolicy{common.ResourcePolicySkipDelete},
+		},
+		{
+			name: "live helm.sh keep retained as skip-delete when chart absent",
+			live: map[string]string{"helm.sh/resource-policy": "keep"},
+			want: []common.ResourcePolicy{common.ResourcePolicySkipDelete},
+		},
+		{
+			name: "live mixed policies filtered to skip-delete when chart absent",
+			live: map[string]string{"werf.io/resource-policy": "skip-update,skip-delete"},
+			want: []common.ResourcePolicy{common.ResourcePolicySkipDelete},
 		},
 		{
 			name:  "chart present takes precedence over live (no merge)",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

