### PR TITLE
fix: don't block deploy when Helm managed fields reconstruction hits incompatible historical manifest

### DIFF
--- a/pkg/kube/error.go
+++ b/pkg/kube/error.go
@@ -12,12 +12,20 @@ func IsImmutableErr(err error) bool {
 	return err != nil && errors.IsInvalid(err) && strings.Contains(err.Error(), validation.FieldImmutableErrorMsg)
 }
 
+func IsInvalidErr(err error) bool {
+	return err != nil && errors.IsInvalid(err)
+}
+
 func IsNoSuchKindErr(err error) bool {
 	return err != nil && meta.IsNoMatchError(err)
 }
 
 func IsNotFoundErr(err error) bool {
 	return err != nil && errors.IsNotFound(err)
+}
+
+func IsTypedObjectErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "failed to create typed patch object")
 }
 
 func IsWebhookErr(err error) bool {

--- a/pkg/kube/error_ai_test.go
+++ b/pkg/kube/error_ai_test.go
@@ -1,0 +1,49 @@
+//go:build ai_tests
+
+package kube
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestAI_IsInvalidErr(t *testing.T) {
+	invalidErr := apierrors.NewInvalid(schema.GroupKind{}, "", field.ErrorList{
+		field.Invalid(field.NewPath("patch"), "", "bad"),
+	})
+
+	assert.True(t, IsInvalidErr(invalidErr))
+	assert.True(t, IsInvalidErr(fmt.Errorf("wrapped: %w", invalidErr)))
+
+	assert.False(t, IsInvalidErr(nil))
+	assert.False(t, IsInvalidErr(apierrors.NewServiceUnavailable("try later")))
+	assert.False(t, IsInvalidErr(apierrors.NewTimeoutError("timed out", 1)))
+	assert.False(t, IsInvalidErr(apierrors.NewInternalError(errors.New("boom"))))
+	assert.False(t, IsInvalidErr(errors.New("connection refused")))
+}
+
+func TestAI_IsTypedObjectErr(t *testing.T) {
+	typedObjErr := fmt.Errorf(`server-side dry-run apply resource "DaemonSet/log-shipper-agent": server-side apply: failed to create typed patch object (d8-log-shipper/log-shipper-agent; apps/v1, Kind=DaemonSet): .spec.template.spec.containers[name="vector"].resources.cpu: field not declared in schema`)
+
+	assert.True(t, IsTypedObjectErr(typedObjErr))
+	assert.True(t, IsTypedObjectErr(fmt.Errorf("wrapped: %w", typedObjErr)))
+
+	assert.False(t, IsTypedObjectErr(nil))
+	assert.False(t, IsTypedObjectErr(apierrors.NewServiceUnavailable("try later")))
+	assert.False(t, IsTypedObjectErr(apierrors.NewInternalError(errors.New("boom"))))
+	assert.False(t, IsTypedObjectErr(errors.New("failed to create typed live object")))
+}
+
+func TestAI_TypedObjectErrIsNotStatusInvalid(t *testing.T) {
+	rawTypedObjErr := fmt.Errorf("failed to create typed patch object: field not declared in schema")
+	serverErr := apierrors.NewGenericServerResponse(500, "PATCH", schema.GroupResource{}, "", rawTypedObjErr.Error(), 0, false)
+
+	assert.False(t, IsInvalidErr(serverErr))
+	assert.True(t, IsTypedObjectErr(serverErr))
+}

--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -516,6 +516,12 @@ func fixHelmUpdateManagedFields(ctx context.Context, localRes *resource.Installa
 		DryRun:           true,
 	})
 	if err != nil {
+		if kube.IsInvalidErr(err) || kube.IsTypedObjectErr(err) {
+			log.Default.Warn(ctx, "Skipping Helm managed fields reconstruction for resource %q: previously deployed manifest is invalid: %s", localRes.IDHuman(), err)
+
+			return origFields, false, nil
+		}
+
 		return nil, false, fmt.Errorf("dry-run apply for helm managed fields fix: %w", err)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

