### PR TITLE
fix: register client-go auth provider plugins

### DIFF
--- a/pkg/kube/client_static.go
+++ b/pkg/kube/client_static.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func NewStaticKubeClientFromKubeConfig(kubeConfig *KubeConfig) (*kubernetes.Clientset, error) {


### PR DESCRIPTION
## Summary

Restores registration of client-go's bundled auth provider plugins by adding the
`_ "k8s.io/client-go/plugin/pkg/client/auth"` side-effect import to `pkg/kube/client_static.go`.
Without it, any kubeconfig relying on an auth provider plugin — notably `oidc` — fails to
construct a Kubernetes client on the v2 line.

## Why

On v2, every command that talks to the cluster fails outright with an `oidc` kubeconfig:

```
$ nelm release plan install -n demo -r demo
Error: release plan install: construct kube client factory: construct static kubernetes client:
  new kube client for config: no Auth Provider found for name "oidc"
```

The same kubeconfig works on v1. Auth provider plugins in client-go register themselves via
package side effects, so something has to blank-import them. On `main` that import lives in
the vendored Helm CLI entrypoint (`pkg/helm/cmd/helm/helm.go:30`). The v2 line dropped that
code, and with it the only import of the plugin package — `git grep 'plugin/pkg/client/auth'`
on branch `2` returns nothing, so registration was silently lost. Nothing failed at build or
init time; the breakage only surfaces at client construction for users whose kubeconfig
actually needs a provider plugin.

## Key changes

**Auth provider registration** — `pkg/kube/client_static.go`

- Added `_ "k8s.io/client-go/plugin/pkg/client/auth"`, re-registering client-go's bundled auth
  provider plugins.
- Registration is process-global, so a single import covers every client built in `pkg/kube`
  (static, dynamic, discovery), not just `NewStaticKubeClientFromKubeConfig`. The static client
  is simply where the failure surfaces first, since `NewClientFactory` builds it before the
  others (`pkg/kube/factory.go:51`).

## Review focus / risks

- **Confirm the import's home is refactor-proof.** This bug was caused by the sole blank import
  disappearing along with the file that held it. `client_static.go` is a plausible spot, but a
  more obvious location (`pkg/kube/common.go`, or a dedicated `auth_plugins.go` with a comment
  explaining it must not be removed) would make it harder to drop again by accident.
- **Confirm which providers the pinned client-go still bundles.** Upstream removed several
  in-tree providers (`gcp`, `azure`, `openstack`) from this meta-package over past releases, so
  this restores whatever the current version ships — verified to cover `oidc` via the reported
  error, but it may not fully restore v1 behavior for users on the removed providers. Worth
  checking the pinned version's package contents before assuming parity with v1.
- **No regression test.** Nothing guards against the import being dropped a third time. A cheap
  guard would be a test asserting `rest.GetAuthProvider`/the provider registry knows `oidc`.
- **Verify against a real OIDC kubeconfig**, ideally beyond `release plan install` — the fix is
  at the client-construction layer, so a single successful command is good evidence, but
  confirming a full `release install` exercises the token-refresh path too.
- Unaffected by this change: `exec` credential plugins and in-cluster/certificate auth live in
  client-go core and never needed registration, so this narrows strictly to the provider-plugin
  path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

