### PR TITLE
feat: port --lookup-resources and --no-create-namespace from main

### DIFF
--- a/cmd/nelm/chart_lint.go
+++ b/cmd/nelm/chart_lint.go
@@ -162,6 +162,14 @@ func newChartLintCommand(ctx context.Context, afterAllCommandsBuiltFuncs map[*co
 			return fmt.Errorf("add flag: %w", err)
 		}
 
+		if err := cli.AddFlag(cmd, &cfg.LocalLookupResourcesPaths, "lookup-resources", nil, "Manifest files used as a cluster stub for the lookup template function in non-remote mode. Multi-document and kind:List supported. Namespaced resources must set metadata.namespace, otherwise namespace-scoped lookups ignore the requested namespace", cli.AddFlagOptions{
+			GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalMultiEnvVarRegexes,
+			Group:                mainFlagGroup,
+			Type:                 cli.FlagTypeFile,
+		}); err != nil {
+			return fmt.Errorf("add flag: %w", err)
+		}
+
 		if err := cli.AddFlag(cmd, &cfg.LocalKubeVersion, "kube-version", common.DefaultLocalKubeVersion, "Kubernetes version stub for non-remote mode", cli.AddFlagOptions{
 			Group: mainFlagGroup,
 		}); err != nil {

--- a/cmd/nelm/chart_render.go
+++ b/cmd/nelm/chart_render.go
@@ -139,6 +139,14 @@ func newChartRenderCommand(ctx context.Context, afterAllCommandsBuiltFuncs map[*
 			return fmt.Errorf("add flag: %w", err)
 		}
 
+		if err := cli.AddFlag(cmd, &cfg.LocalLookupResourcesPaths, "lookup-resources", nil, "Manifest files used as a cluster stub for the lookup template function in non-remote mode. Multi-document and kind:List supported. Namespaced resources must set metadata.namespace, otherwise namespace-scoped lookups ignore the requested namespace", cli.AddFlagOptions{
+			GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalMultiEnvVarRegexes,
+			Group:                mainFlagGroup,
+			Type:                 cli.FlagTypeFile,
+		}); err != nil {
+			return fmt.Errorf("add flag: %w", err)
+		}
+
 		if err := cli.AddFlag(cmd, &cfg.LocalKubeVersion, "kube-version", common.DefaultLocalKubeVersion, "Kubernetes version stub for non-remote mode", cli.AddFlagOptions{
 			Group: mainFlagGroup,
 		}); err != nil {

--- a/cmd/nelm/release_install.go
+++ b/cmd/nelm/release_install.go
@@ -206,6 +206,13 @@ func newReleaseInstallCommand(ctx context.Context, afterAllCommandsBuiltFuncs ma
 			return fmt.Errorf("add flag: %w", err)
 		}
 
+		if err := cli.AddFlag(cmd, &cfg.NoCreateNamespace, "no-create-namespace", false, "Don't create the release namespace", cli.AddFlagOptions{
+			GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
+			Group:                mainFlagGroup,
+		}); err != nil {
+			return fmt.Errorf("add flag: %w", err)
+		}
+
 		if err := cli.AddFlag(cmd, &cfg.NoShowNotes, "no-notes", false, "Don't show release notes at the end of the release", cli.AddFlagOptions{
 			Group: mainFlagGroup,
 		}); err != nil {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2090,6 +2090,10 @@ nelm chart lint [options...] [chart-dir|chart-repo-name/chart-name|chart-archive
 
   Kubernetes version stub for non\-remote mode\. Var: \$NELM\_CHART\_LINT\_KUBE\_VERSION
 
+- `--lookup-resources` (default: `[]`)
+
+  Manifest files used as a cluster stub for the lookup template function in non\-remote mode\. Multi\-document and kind:List supported\. Namespaced resources must set metadata\.namespace, otherwise namespace\-scoped lookups ignore the requested namespace\. Vars: \$NELM\_LOOKUP\_RESOURCES\_\*, \$NELM\_CHART\_LINT\_LOOKUP\_RESOURCES\_\*
+
 - `-n`, `--namespace` (default: `"stub-namespace"`)
 
   The release namespace\. Resources with no namespace will be deployed here\. Vars: \$NELM\_NAMESPACE, \$NELM\_CHART\_LINT\_NAMESPACE
@@ -2468,6 +2472,10 @@ nelm chart render [options...] [chart-dir|chart-repo-name/chart-name|chart-archi
 - `--kube-version` (default: `"1.36.0"`)
 
   Kubernetes version stub for non\-remote mode\. Var: \$NELM\_CHART\_RENDER\_KUBE\_VERSION
+
+- `--lookup-resources` (default: `[]`)
+
+  Manifest files used as a cluster stub for the lookup template function in non\-remote mode\. Multi\-document and kind:List supported\. Namespaced resources must set metadata\.namespace, otherwise namespace\-scoped lookups ignore the requested namespace\. Vars: \$NELM\_LOOKUP\_RESOURCES\_\*, \$NELM\_CHART\_RENDER\_LOOKUP\_RESOURCES\_\*
 
 - `-n`, `--namespace` (default: `"stub-namespace"`)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -143,6 +143,10 @@ nelm release install [options...] -n namespace -r release [chart-dir|chart-repo-
 
   The release namespace\. Resources with no namespace will be deployed here\. Vars: \$NELM\_NAMESPACE, \$NELM\_RELEASE\_INSTALL\_NAMESPACE
 
+- `--no-create-namespace` (default: `false`)
+
+  Don't create the release namespace\. Vars: \$NELM\_NO\_CREATE\_NAMESPACE, \$NELM\_RELEASE\_INSTALL\_NO\_CREATE\_NAMESPACE
+
 - `--no-install-crds` (default: `false`)
 
   Don't install CRDs from "crds/" directories of installed charts\. Var: \$NELM\_RELEASE\_INSTALL\_NO\_INSTALL\_CRDS

--- a/pkg/action/chart_lint.go
+++ b/pkg/action/chart_lint.go
@@ -96,6 +96,14 @@ type ChartLintOptions struct {
 	// LocalKubeVersion specifies the Kubernetes version to use for linting when not connected to a cluster.
 	// Format: "major.minor.patch" (e.g., "1.28.0"). Defaults to DefaultLocalKubeVersion if not set.
 	LocalKubeVersion string
+	// LocalLookupResourcesPaths are paths to YAML or JSON manifest files whose resources the "lookup"
+	// template function resolves against in local mode (Remote=false), instead of a live cluster.
+	// Each file may hold multiple documents separated by "---" and/or a kind: List (or typed *List)
+	// wrapper whose items are expanded; a bare top-level JSON array is not supported. Duplicate
+	// resources are rejected. Ignored if Remote is true. Namespace scope is inferred from
+	// whether a resource sets metadata.namespace; namespaced resources must set it, otherwise
+	// namespace-scoped lookups ignore the requested namespace and match the resource regardless.
+	LocalLookupResourcesPaths []string
 	// NetworkParallelism limits the number of concurrent network-related operations (API calls, resource fetches).
 	// Defaults to DefaultNetworkParallelism if not set or <= 0.
 	NetworkParallelism int
@@ -266,6 +274,7 @@ func ChartLint(ctx context.Context, opts ChartLintOptions) error {
 		TempDirPath:                     opts.TempDirPath,
 		IgnoreBundleJS:                  opts.IgnoreBundleJS,
 		DenoBinaryPath:                  opts.DenoBinaryPath,
+		LocalLookupResourcesPaths:       opts.LocalLookupResourcesPaths,
 	}
 
 	log.Default.Debug(ctx, "Render chart")

--- a/pkg/action/chart_render.go
+++ b/pkg/action/chart_render.go
@@ -89,6 +89,14 @@ type ChartRenderOptions struct {
 	// LocalKubeVersion specifies the Kubernetes version to use for template rendering when not connected to a cluster.
 	// Format: "major.minor.patch" (e.g., "1.28.0"). Defaults to DefaultLocalKubeVersion if not set.
 	LocalKubeVersion string
+	// LocalLookupResourcesPaths are paths to YAML or JSON manifest files whose resources the "lookup"
+	// template function resolves against in local mode (Remote=false), instead of a live cluster.
+	// Each file may hold multiple documents separated by "---" and/or a kind: List (or typed *List)
+	// wrapper whose items are expanded; a bare top-level JSON array is not supported. Duplicate
+	// resources are rejected. Ignored if Remote is true. Namespace scope is inferred from
+	// whether a resource sets metadata.namespace; namespaced resources must set it, otherwise
+	// namespace-scoped lookups ignore the requested namespace and match the resource regardless.
+	LocalLookupResourcesPaths []string
 	// NetworkParallelism limits the number of concurrent network-related operations (API calls, resource fetches).
 	// Defaults to DefaultNetworkParallelism if not set or <= 0.
 	NetworkParallelism int
@@ -264,6 +272,7 @@ func ChartRender(ctx context.Context, opts ChartRenderOptions) (*ChartRenderResu
 		TempDirPath:                     opts.TempDirPath,
 		IgnoreBundleJS:                  opts.IgnoreBundleJS,
 		DenoBinaryPath:                  opts.DenoBinaryPath,
+		LocalLookupResourcesPaths:       opts.LocalLookupResourcesPaths,
 	}
 
 	log.Default.Debug(ctx, "Render chart")

--- a/pkg/action/release_install.go
+++ b/pkg/action/release_install.go
@@ -108,6 +108,8 @@ type ReleaseInstallOptions struct {
 	// NetworkParallelism limits the number of concurrent network-related operations (API calls, resource fetches).
 	// Defaults to DefaultNetworkParallelism if not set or <= 0.
 	NetworkParallelism int
+	// NoCreateNamespace, when true, skips creating the release namespace entirely.
+	NoCreateNamespace bool
 	// NoShowNotes, when true, suppresses printing of NOTES.txt after successful installation.
 	// NOTES.txt typically contains usage instructions and next steps.
 	NoShowNotes bool
@@ -275,8 +277,10 @@ func releaseInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc, re
 		lockManager = m
 	}
 
-	if err := createReleaseNamespace(ctx, clientFactory, releaseNamespace); err != nil {
-		return fmt.Errorf("create release namespace: %w", err)
+	if !opts.NoCreateNamespace {
+		if err := createReleaseNamespace(ctx, clientFactory, releaseNamespace); err != nil {
+			return fmt.Errorf("create release namespace: %w", err)
+		}
 	}
 
 	log.Default.Info(ctx, color.Style{color.Bold, color.Green}.Render("Start release")+" %q (namespace: %q)", releaseName, releaseNamespace)
@@ -766,8 +770,19 @@ func applyReleaseInstallOptionsDefaults(opts ReleaseInstallOptions, currentDir, 
 	return opts, nil
 }
 
-func createReleaseNamespace(ctx context.Context, clientFactory *kube.ClientFactory, releaseNamespace string) error {
-	unstruct := &unstructured.Unstructured{
+func createReleaseNamespace(ctx context.Context, clientFactory kube.ClientFactorier, releaseNamespace string) error {
+	cmUnstruct := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      common.LockConfigMapName,
+				"namespace": releaseNamespace,
+			},
+		},
+	}
+
+	nsUnstruct := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "Namespace",
@@ -777,21 +792,38 @@ func createReleaseNamespace(ctx context.Context, clientFactory *kube.ClientFacto
 		},
 	}
 
-	resSpec := spec.NewResourceSpec(unstruct, releaseNamespace, spec.ResourceSpecOptions{})
+	cmResSpec := spec.NewResourceSpec(cmUnstruct, releaseNamespace, spec.ResourceSpecOptions{})
+	nsResSpec := spec.NewResourceSpec(nsUnstruct, releaseNamespace, spec.ResourceSpecOptions{})
 
-	if _, err := clientFactory.KubeClient().Get(ctx, resSpec.ResourceMeta, kube.KubeClientGetOptions{
-		TryCache: true,
-	}); err != nil {
-		if kube.IsNotFoundErr(err) {
-			log.Default.Debug(ctx, "Create release namespace %q", releaseNamespace)
+	_, cmApplyErr := clientFactory.KubeClient().Apply(ctx, cmResSpec, kube.KubeClientApplyOptions{
+		DefaultNamespace: releaseNamespace,
+		DryRun:           true,
+	})
+	if cmApplyErr == nil {
+		return nil
+	}
 
-			if _, err := clientFactory.KubeClient().Create(ctx, resSpec, kube.KubeClientCreateOptions{}); err != nil {
-				return fmt.Errorf("create release namespace: %w", err)
-			}
-		} else if errors.IsForbidden(err) {
-		} else {
-			return fmt.Errorf("get release namespace: %w", err)
+	if !errors.IsForbidden(cmApplyErr) && !errors.IsNotFound(cmApplyErr) {
+		return fmt.Errorf("dry-run apply release synchronization configmap: %w", cmApplyErr)
+	}
+
+	if _, nsApplyErr := clientFactory.KubeClient().Apply(ctx, nsResSpec, kube.KubeClientApplyOptions{
+		DefaultNamespace: releaseNamespace,
+		DryRun:           true,
+	}); nsApplyErr != nil {
+		if errors.IsForbidden(nsApplyErr) || errors.IsNotFound(nsApplyErr) {
+			allErr := &util.MultiError{}
+
+			return fmt.Errorf("can't apply ConfigMap for locking, and can't apply release namespace (in case ConfigMap apply error caused by non-existent namespace): %w", allErr.Add(cmApplyErr, nsApplyErr))
 		}
+
+		return fmt.Errorf("dry-run apply release namespace: %w", nsApplyErr)
+	}
+
+	log.Default.Debug(ctx, "Ensure release namespace %q", releaseNamespace)
+
+	if _, err := clientFactory.KubeClient().Create(ctx, nsResSpec, kube.KubeClientCreateOptions{}); err != nil {
+		return fmt.Errorf("create release namespace: %w", err)
 	}
 
 	return nil

--- a/pkg/action/release_install_ai_test.go
+++ b/pkg/action/release_install_ai_test.go
@@ -1,0 +1,251 @@
+//go:build ai_tests
+
+package action
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/werf/nelm/pkg/kube"
+	"github.com/werf/nelm/pkg/resource/spec"
+)
+
+var (
+	_ kube.ClientFactorier = (*createNamespaceClientFactory)(nil)
+	_ kube.KubeClienter    = (*createNamespaceKubeClient)(nil)
+)
+
+type createNamespaceClientFactory struct {
+	kubeClient kube.KubeClienter
+}
+
+func (f *createNamespaceClientFactory) Discovery() discovery.CachedDiscoveryInterface {
+	panic("not implemented")
+}
+
+func (f *createNamespaceClientFactory) Dynamic() dynamic.Interface {
+	panic("not implemented")
+}
+
+func (f *createNamespaceClientFactory) KubeClient() kube.KubeClienter {
+	return f.kubeClient
+}
+
+func (f *createNamespaceClientFactory) KubeConfig() *kube.KubeConfig {
+	panic("not implemented")
+}
+
+func (f *createNamespaceClientFactory) LegacyClientGetter() *kube.LegacyClientGetter {
+	panic("not implemented")
+}
+
+func (f *createNamespaceClientFactory) Mapper() apimeta.ResettableRESTMapper {
+	panic("not implemented")
+}
+
+func (f *createNamespaceClientFactory) Static() kubernetes.Interface {
+	panic("not implemented")
+}
+
+type createNamespaceCall struct {
+	dryRun bool
+	kind   string
+}
+
+type createNamespaceKubeClient struct {
+	calls       []createNamespaceCall
+	cmApplyErr  error
+	nsApplyErr  error
+	nsCreateErr error
+}
+
+func (c *createNamespaceKubeClient) Apply(ctx context.Context, resSpec *spec.ResourceSpec, opts kube.KubeClientApplyOptions) (*unstructured.Unstructured, error) {
+	kind := resSpec.GroupVersionKind.Kind
+	c.calls = append(c.calls, createNamespaceCall{dryRun: opts.DryRun, kind: kind})
+
+	switch kind {
+	case "ConfigMap":
+		return nil, c.cmApplyErr
+	case "Namespace":
+		return nil, c.nsApplyErr
+	default:
+		panic("unexpected apply kind: " + kind)
+	}
+}
+
+func (c *createNamespaceKubeClient) Create(ctx context.Context, resSpec *spec.ResourceSpec, opts kube.KubeClientCreateOptions) (*unstructured.Unstructured, error) {
+	c.calls = append(c.calls, createNamespaceCall{dryRun: false, kind: resSpec.GroupVersionKind.Kind})
+
+	return nil, c.nsCreateErr
+}
+
+func (c *createNamespaceKubeClient) Delete(ctx context.Context, meta *spec.ResourceMeta, opts kube.KubeClientDeleteOptions) error {
+	panic("not implemented")
+}
+
+func (c *createNamespaceKubeClient) GVKToGVR(ctx context.Context, gvk schema.GroupVersionKind) (schema.GroupVersionResource, bool, error) {
+	panic("not implemented")
+}
+
+func (c *createNamespaceKubeClient) Get(ctx context.Context, meta *spec.ResourceMeta, opts kube.KubeClientGetOptions) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func (c *createNamespaceKubeClient) MergePatch(ctx context.Context, meta *spec.ResourceMeta, patch []byte, opts kube.KubeClientMergePatchOptions) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func (c *createNamespaceKubeClient) Namespaced(ctx context.Context, gvk schema.GroupVersionKind) (bool, error) {
+	panic("not implemented")
+}
+
+func (c *createNamespaceKubeClient) ResetAndRetryOnUnknownGVR(ctx context.Context, fn func() error) error {
+	panic("not implemented")
+}
+
+func (c *createNamespaceKubeClient) ResetDiscoveryCache(ctx context.Context) error {
+	panic("not implemented")
+}
+
+func (c *createNamespaceKubeClient) ServerVersion(ctx context.Context) (*version.Info, error) {
+	panic("not implemented")
+}
+
+func TestAI_CreateReleaseNamespaceBothProbesForbiddenAggregates(t *testing.T) {
+	cmErr := newForbiddenErr("configmaps", "werf-synchronization")
+	nsErr := newForbiddenErr("namespaces", "my-namespace")
+	kubeClient := &createNamespaceKubeClient{cmApplyErr: cmErr, nsApplyErr: nsErr}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.Error(t, err)
+	require.ErrorIs(t, err, cmErr)
+	require.ErrorIs(t, err, nsErr)
+	assert.Contains(t, err.Error(), "can't apply ConfigMap for locking, and can't apply release namespace")
+
+	require.Len(t, kubeClient.calls, 2)
+	assert.Equal(t, createNamespaceCall{dryRun: true, kind: "ConfigMap"}, kubeClient.calls[0])
+	assert.Equal(t, createNamespaceCall{dryRun: true, kind: "Namespace"}, kubeClient.calls[1])
+}
+
+func TestAI_CreateReleaseNamespaceConfigMapForbiddenNamespaceNotFoundAggregates(t *testing.T) {
+	cmErr := newForbiddenErr("configmaps", "werf-synchronization")
+	nsErr := newNotFoundErr("namespaces", "my-namespace")
+	kubeClient := &createNamespaceKubeClient{cmApplyErr: cmErr, nsApplyErr: nsErr}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.Error(t, err)
+	require.ErrorIs(t, err, cmErr)
+	require.ErrorIs(t, err, nsErr)
+
+	require.Len(t, kubeClient.calls, 2)
+}
+
+func TestAI_CreateReleaseNamespaceConfigMapForbiddenThenNamespaceCreated(t *testing.T) {
+	kubeClient := &createNamespaceKubeClient{
+		cmApplyErr: newForbiddenErr("configmaps", "werf-synchronization"),
+	}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.NoError(t, err)
+
+	require.Len(t, kubeClient.calls, 3)
+	assert.Equal(t, createNamespaceCall{dryRun: true, kind: "ConfigMap"}, kubeClient.calls[0])
+	assert.Equal(t, createNamespaceCall{dryRun: true, kind: "Namespace"}, kubeClient.calls[1])
+	assert.Equal(t, createNamespaceCall{dryRun: false, kind: "Namespace"}, kubeClient.calls[2])
+}
+
+func TestAI_CreateReleaseNamespaceConfigMapNotFoundThenNamespaceCreated(t *testing.T) {
+	kubeClient := &createNamespaceKubeClient{
+		cmApplyErr: newNotFoundErr("configmaps", "werf-synchronization"),
+	}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.NoError(t, err)
+
+	require.Len(t, kubeClient.calls, 3)
+	assert.Equal(t, createNamespaceCall{dryRun: true, kind: "ConfigMap"}, kubeClient.calls[0])
+	assert.Equal(t, createNamespaceCall{dryRun: true, kind: "Namespace"}, kubeClient.calls[1])
+	assert.Equal(t, createNamespaceCall{dryRun: false, kind: "Namespace"}, kubeClient.calls[2])
+}
+
+func TestAI_CreateReleaseNamespaceConfigMapOtherErrorPropagates(t *testing.T) {
+	cmErr := errors.New("connection refused")
+	kubeClient := &createNamespaceKubeClient{cmApplyErr: cmErr}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.Error(t, err)
+	require.ErrorIs(t, err, cmErr)
+
+	require.Len(t, kubeClient.calls, 1)
+	assert.Equal(t, "ConfigMap", kubeClient.calls[0].kind)
+}
+
+func TestAI_CreateReleaseNamespaceConfigMapProbeSucceeds(t *testing.T) {
+	kubeClient := &createNamespaceKubeClient{}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.NoError(t, err)
+
+	require.Len(t, kubeClient.calls, 1)
+	assert.Equal(t, "ConfigMap", kubeClient.calls[0].kind)
+	assert.True(t, kubeClient.calls[0].dryRun)
+}
+
+func TestAI_CreateReleaseNamespaceNamespaceProbeOtherErrorPropagates(t *testing.T) {
+	nsErr := errors.New("connection refused")
+	kubeClient := &createNamespaceKubeClient{
+		cmApplyErr: newForbiddenErr("configmaps", "werf-synchronization"),
+		nsApplyErr: nsErr,
+	}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.Error(t, err)
+	require.ErrorIs(t, err, nsErr)
+	assert.Contains(t, err.Error(), "dry-run apply release namespace")
+
+	require.Len(t, kubeClient.calls, 2)
+}
+
+func TestAI_CreateReleaseNamespaceRealCreateFailurePropagates(t *testing.T) {
+	createErr := errors.New("quota exceeded")
+	kubeClient := &createNamespaceKubeClient{
+		cmApplyErr:  newForbiddenErr("configmaps", "werf-synchronization"),
+		nsCreateErr: createErr,
+	}
+	clientFactory := &createNamespaceClientFactory{kubeClient: kubeClient}
+
+	err := createReleaseNamespace(context.Background(), clientFactory, "my-namespace")
+	require.Error(t, err)
+	require.ErrorIs(t, err, createErr)
+	assert.Contains(t, err.Error(), "create release namespace")
+
+	require.Len(t, kubeClient.calls, 3)
+	assert.Equal(t, createNamespaceCall{dryRun: false, kind: "Namespace"}, kubeClient.calls[2])
+}
+
+func newForbiddenErr(resource, name string) error {
+	return apierrors.NewForbidden(schema.GroupResource{Resource: resource}, name, errors.New("forbidden"))
+}
+
+func newNotFoundErr(resource, name string) error {
+	return apierrors.NewNotFound(schema.GroupResource{Resource: resource}, name)
+}

--- a/pkg/chart/chart_render.go
+++ b/pkg/chart/chart_render.go
@@ -14,7 +14,10 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/werf/nelm/pkg/common"
 	"github.com/werf/nelm/pkg/featgate"
@@ -56,6 +59,7 @@ type RenderChartOptions struct {
 	HelmOptions                     common.HelmOptions
 	IgnoreBundleJS                  bool
 	LocalKubeVersion                string
+	LocalLookupResourcesPaths       []string
 	NoStandaloneCRDs                bool
 	NoValuesSchemaValidation        bool
 	Remote                          bool
@@ -233,7 +237,15 @@ func RenderChart(ctx context.Context, chartPath, releaseName, releaseNamespace s
 	if opts.Remote && clientFactory.KubeClient() != nil {
 		engine = lo.ToPtr(helmengine.New(clientFactory.KubeConfig().RestConfig))
 	} else {
-		engine = lo.ToPtr(helmengine.Engine{})
+		engine = &helmengine.Engine{}
+		if len(opts.LocalLookupResourcesPaths) > 0 {
+			localLookupResources, err := parseLocalLookupResources(opts.LocalLookupResourcesPaths)
+			if err != nil {
+				return nil, fmt.Errorf("parse local lookup resources: %w", err)
+			}
+
+			engine.SetClientProvider(newLocalClientProvider(localLookupResources))
+		}
 	}
 
 	engine.EnableDNS = opts.TemplatesAllowDNS
@@ -328,6 +340,61 @@ func RenderChart(ctx context.Context, chartPath, releaseName, releaseNamespace s
 	}, nil
 }
 
+func parseLocalLookupResources(paths []string) ([]*unstructured.Unstructured, error) {
+	var resources []*unstructured.Unstructured
+
+	seen := make(map[string]bool)
+
+	for _, filePath := range paths {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("read file %q: %w", filePath, err)
+		}
+
+		for i, manifest := range util.SplitManifestsKeepingEmpty(string(content)) {
+			if manifest == "" {
+				continue
+			}
+
+			obj, _, err := scheme.Codecs.UniversalDecoder().Decode([]byte(manifest), nil, &unstructured.Unstructured{})
+			if err != nil {
+				return nil, fmt.Errorf("decode resource #%d for %q: %w", i+1, filePath, err)
+			}
+
+			unstruct := obj.(*unstructured.Unstructured)
+
+			if unstruct.IsList() {
+				item := 0
+
+				if err := unstruct.EachListItem(func(o runtime.Object) error {
+					res, err := collectLocalLookupResource(o.(*unstructured.Unstructured), seen)
+					if err != nil {
+						return err
+					}
+
+					item++
+					resources = append(resources, res)
+
+					return nil
+				}); err != nil {
+					return nil, fmt.Errorf("collect resource #%d for %q (item %d): %w", i+1, filePath, item+1, err)
+				}
+
+				continue
+			}
+
+			res, err := collectLocalLookupResource(unstruct, seen)
+			if err != nil {
+				return nil, fmt.Errorf("collect resource #%d for %q: %w", i+1, filePath, err)
+			}
+
+			resources = append(resources, res)
+		}
+	}
+
+	return resources, nil
+}
+
 func buildChartCapabilities(ctx context.Context, clientFactory kube.ClientFactorier, opts buildChartCapabilitiesOptions) (*chartcommon.Capabilities, error) {
 	capabilities := &chartcommon.Capabilities{
 		HelmVersion: chartcommon.DefaultCapabilities.HelmVersion,
@@ -420,6 +487,27 @@ func buildContextFromJSONSets(jsonSets []string) (map[string]interface{}, error)
 	}
 
 	return context, nil
+}
+
+func collectLocalLookupResource(unstruct *unstructured.Unstructured, seen map[string]bool) (*unstructured.Unstructured, error) {
+	if unstruct.GetAPIVersion() == "" {
+		return nil, fmt.Errorf("apiVersion is missing")
+	}
+
+	if unstruct.GetName() == "" {
+		return nil, fmt.Errorf("name is missing")
+	}
+
+	gvk := unstruct.GroupVersionKind()
+	id := spec.IDWithVersion(unstruct.GetName(), unstruct.GetNamespace(), gvk.Group, gvk.Version, gvk.Kind)
+
+	if seen[id] {
+		return nil, fmt.Errorf("duplicate resource %s", spec.IDHuman(unstruct.GetName(), unstruct.GetNamespace(), gvk.Group, gvk.Kind))
+	}
+
+	seen[id] = true
+
+	return unstruct, nil
 }
 
 func isLocalChart(path string) bool {

--- a/pkg/chart/lookup.go
+++ b/pkg/chart/lookup.go
@@ -1,0 +1,102 @@
+package chart
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/werf/nelm/pkg/helm/pkg/engine"
+)
+
+var (
+	_ engine.ClientProvider                  = (*LocalClientProvider)(nil)
+	_ dynamic.NamespaceableResourceInterface = (*emptyListResource)(nil)
+)
+
+type LocalClientProvider struct {
+	client     *fake.FakeDynamicClient
+	namespaced map[schema.GroupVersionKind]bool
+	registered map[schema.GroupVersionKind]bool
+}
+
+// newLocalClientProvider returns an engine.ClientProvider that resolves lookup calls against the
+// provided in-memory set of Kubernetes objects instead of a live cluster. An empty set makes
+// every lookup return an empty result, matching the offline stub behavior.
+func newLocalClientProvider(objects []*unstructured.Unstructured) *LocalClientProvider {
+	runtimeObjects := make([]runtime.Object, 0, len(objects))
+
+	registered := make(map[schema.GroupVersionKind]bool)
+
+	namespaced := make(map[schema.GroupVersionKind]bool)
+	for _, obj := range objects {
+		runtimeObjects = append(runtimeObjects, obj)
+		if obj.GetNamespace() != "" {
+			namespaced[obj.GroupVersionKind()] = true
+		}
+
+		registered[obj.GroupVersionKind()] = true
+	}
+
+	return &LocalClientProvider{
+		client:     fake.NewSimpleDynamicClient(runtime.NewScheme(), runtimeObjects...),
+		namespaced: namespaced,
+		registered: registered,
+	}
+}
+
+func (p *LocalClientProvider) GetClientFor(apiVersion, kind string) (dynamic.NamespaceableResourceInterface, bool, error) {
+	gvk := schema.FromAPIVersionAndKind(apiVersion, kind)
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+
+	if !p.registered[gvk] {
+		return &emptyListResource{
+			NamespaceableResourceInterface: p.client.Resource(gvr),
+			listGVK:                        gvk.GroupVersion().WithKind(gvk.Kind + "List"),
+		}, p.namespaced[gvk], nil
+	}
+
+	return p.client.Resource(gvr), p.namespaced[gvk], nil
+}
+
+// emptyListResource wraps a fake dynamic resource interface for a kind with no registered objects,
+// so that List returns an empty list (the fake client would otherwise panic for an unregistered
+// list kind), matching the offline stub semantics where an absent kind yields an empty result.
+type emptyListResource struct {
+	dynamic.NamespaceableResourceInterface
+
+	listGVK schema.GroupVersionKind
+}
+
+func (r *emptyListResource) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return listEmpty(r.listGVK)
+}
+
+func (r *emptyListResource) Namespace(namespace string) dynamic.ResourceInterface {
+	return &emptyListNamespacedResource{
+		ResourceInterface: r.NamespaceableResourceInterface.Namespace(namespace),
+		listGVK:           r.listGVK,
+	}
+}
+
+type emptyListNamespacedResource struct {
+	dynamic.ResourceInterface
+
+	listGVK schema.GroupVersionKind
+}
+
+func (r *emptyListNamespacedResource) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return listEmpty(r.listGVK)
+}
+
+func listEmpty(listGVK schema.GroupVersionKind) (*unstructured.UnstructuredList, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(listGVK)
+
+	return list, nil
+}

--- a/pkg/chart/lookup_ai_test.go
+++ b/pkg/chart/lookup_ai_test.go
@@ -1,0 +1,177 @@
+//go:build ai_tests
+
+package chart
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	helmchart "github.com/werf/nelm/pkg/helm/pkg/chart"
+	"github.com/werf/nelm/pkg/helm/pkg/chartutil"
+	"github.com/werf/nelm/pkg/helm/pkg/engine"
+	"github.com/werf/nelm/pkg/helm/pkg/werf/helmopts"
+)
+
+func TestAI_LocalClientProviderEmpty(t *testing.T) {
+	provider := newLocalClientProvider(nil)
+
+	c := &helmchart.Chart{
+		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
+		Templates: []*helmchart.File{
+			{Name: "templates/empty", Data: []byte(`{{ (lookup "v1" "Pod" "default" "pod1") }}`)},
+		},
+		Values: map[string]any{},
+	}
+
+	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	require.NoError(t, err)
+
+	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "map[]", out["moby/templates/empty"])
+}
+
+func TestAI_LocalClientProviderLookup(t *testing.T) {
+	provider := newLocalClientProvider([]*unstructured.Unstructured{
+		makeUnstructured("v1", "Namespace", "default", ""),
+		makeUnstructured("v1", "Pod", "pod1", "default"),
+		makeUnstructured("v1", "Pod", "pod2", "ns1"),
+		makeUnstructured("v1", "Pod", "pod3", "ns1"),
+	})
+
+	templates := map[string]string{
+		"cluster-single":  `{{ (lookup "v1" "Namespace" "" "default").metadata.name }}`,
+		"namespaced-get":  `{{ (lookup "v1" "Pod" "default" "pod1").metadata.name }}`,
+		"namespaced-list": `{{ (lookup "v1" "Pod" "ns1" "").items | len }}`,
+		"all-ns-list":     `{{ (lookup "v1" "Pod" "" "").items | len }}`,
+		"missing-get":     `{{ (lookup "v1" "Pod" "" "absent") }}`,
+	}
+	expected := map[string]string{
+		"cluster-single":  "default",
+		"namespaced-get":  "pod1",
+		"namespaced-list": "2",
+		"all-ns-list":     "3",
+		"missing-get":     "map[]",
+	}
+
+	c := &helmchart.Chart{
+		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
+		Values:   map[string]any{},
+	}
+
+	for name, tpl := range templates {
+		c.Templates = append(c.Templates, &helmchart.File{
+			Name: path.Join("templates", name),
+			Data: []byte(tpl),
+		})
+	}
+
+	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	require.NoError(t, err)
+
+	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	require.NoError(t, err)
+
+	for name, want := range expected {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, want, out[path.Join("moby/templates", name)])
+		})
+	}
+}
+
+func TestAI_LocalClientProviderNamespaceIsolation(t *testing.T) {
+	provider := newLocalClientProvider([]*unstructured.Unstructured{
+		makeUnstructured("v1", "Pod", "pod1", "default"),
+	})
+
+	templates := map[string]string{
+		"same-ns-get":  `{{ (lookup "v1" "Pod" "default" "pod1").metadata.name }}`,
+		"other-ns-get": `{{ (lookup "v1" "Pod" "other" "pod1") }}`,
+	}
+	expected := map[string]string{
+		"same-ns-get":  "pod1",
+		"other-ns-get": "map[]",
+	}
+
+	c := &helmchart.Chart{
+		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
+		Values:   map[string]any{},
+	}
+
+	for name, tpl := range templates {
+		c.Templates = append(c.Templates, &helmchart.File{
+			Name: path.Join("templates", name),
+			Data: []byte(tpl),
+		})
+	}
+
+	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	require.NoError(t, err)
+
+	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	require.NoError(t, err)
+
+	for name, want := range expected {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, want, out[path.Join("moby/templates", name)])
+		})
+	}
+}
+
+func TestAI_LocalClientProviderUnstubbedListEmptyProvider(t *testing.T) {
+	provider := newLocalClientProvider(nil)
+
+	c := &helmchart.Chart{
+		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
+		Templates: []*helmchart.File{
+			{Name: "templates/list", Data: []byte(`{{ (lookup "v1" "Pod" "" "").items | len }}`)},
+		},
+		Values: map[string]any{},
+	}
+
+	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	require.NoError(t, err)
+
+	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "0", out["moby/templates/list"])
+}
+
+func TestAI_LocalClientProviderUnstubbedListOtherKind(t *testing.T) {
+	provider := newLocalClientProvider([]*unstructured.Unstructured{
+		makeUnstructured("v1", "Pod", "pod1", "default"),
+	})
+
+	c := &helmchart.Chart{
+		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
+		Templates: []*helmchart.File{
+			{Name: "templates/list", Data: []byte(`{{ (lookup "v1" "ConfigMap" "" "").items | len }}`)},
+		},
+		Values: map[string]any{},
+	}
+
+	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	require.NoError(t, err)
+
+	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "0", out["moby/templates/list"])
+}
+
+func makeUnstructured(apiVersion, kind, name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name": name,
+		},
+	}}
+	if namespace != "" {
+		obj.Object["metadata"].(map[string]interface{})["namespace"] = namespace
+	}
+
+	return obj
+}

--- a/pkg/chart/parse_local_lookup_resources_ai_test.go
+++ b/pkg/chart/parse_local_lookup_resources_ai_test.go
@@ -1,0 +1,163 @@
+//go:build ai_tests
+
+package chart
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_ParseLocalLookupResourcesDuplicateAfterExpansion(t *testing.T) {
+	path := writeLocalLookupFile(t, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod1
+      namespace: default
+`)
+
+	_, err := parseLocalLookupResources([]string{path})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate resource")
+	require.Contains(t, err.Error(), "item 1")
+}
+
+func TestAI_ParseLocalLookupResourcesListExpansion(t *testing.T) {
+	path := writeLocalLookupFile(t, `
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod1
+      namespace: default
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod2
+      namespace: default
+`)
+
+	resources, err := parseLocalLookupResources([]string{path})
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	require.Equal(t, "pod1", resources[0].GetName())
+	require.Equal(t, "pod2", resources[1].GetName())
+	for _, r := range resources {
+		require.Equal(t, "Pod", r.GetKind())
+	}
+}
+
+func TestAI_ParseLocalLookupResourcesListItemMissingAPIVersion(t *testing.T) {
+	path := writeLocalLookupFile(t, `
+apiVersion: v1
+kind: List
+items:
+  - kind: Pod
+    metadata:
+      name: pod1
+      namespace: default
+`)
+
+	_, err := parseLocalLookupResources([]string{path})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "apiVersion is missing")
+	require.Contains(t, err.Error(), "item 1")
+}
+
+func TestAI_ParseLocalLookupResourcesMultiDoc(t *testing.T) {
+	path := writeLocalLookupFile(t, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: default
+`)
+
+	resources, err := parseLocalLookupResources([]string{path})
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	require.Equal(t, "Pod", resources[0].GetKind())
+	require.Equal(t, "ConfigMap", resources[1].GetKind())
+}
+
+func TestAI_ParseLocalLookupResourcesTopLevelDuplicate(t *testing.T) {
+	path := writeLocalLookupFile(t, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+`)
+
+	_, err := parseLocalLookupResources([]string{path})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate resource")
+}
+
+func TestAI_ParseLocalLookupResourcesTopLevelMissingAPIVersion(t *testing.T) {
+	path := writeLocalLookupFile(t, `
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+`)
+
+	_, err := parseLocalLookupResources([]string{path})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "apiVersion is missing")
+}
+
+func TestAI_ParseLocalLookupResourcesTypedListExpansion(t *testing.T) {
+	path := writeLocalLookupFile(t, `
+apiVersion: v1
+kind: PodList
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod1
+      namespace: default
+`)
+
+	resources, err := parseLocalLookupResources([]string{path})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	require.Equal(t, "Pod", resources[0].GetKind())
+	require.Equal(t, "pod1", resources[0].GetName())
+}
+
+func writeLocalLookupFile(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resources.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	return path
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -127,6 +127,7 @@ const (
 	DefaultResourceValidationKubeVersion = "1.35.0"
 	DefaultWebhookRetryTimeout           = 4 * time.Minute
 	KubectlEditFieldManager              = "kubectl-edit"
+	LockConfigMapName                    = "werf-synchronization"
 	OldFieldManagerPrefix                = "werf"
 	OutputFormatJSON                     = "json"
 	OutputFormatTable                    = "table"

--- a/pkg/helm/pkg/engine/engine.go
+++ b/pkg/helm/pkg/engine/engine.go
@@ -70,6 +70,12 @@ func New(config *rest.Config) Engine {
 	}
 }
 
+// SetClientProvider sets the ClientProvider used to resolve lookup calls. It allows resolving
+// lookups against a custom source, such as an in-memory set of objects in offline mode.
+func (e *Engine) SetClientProvider(clientProvider ClientProvider) {
+	e.clientProvider = &clientProvider
+}
+
 // Render takes a chart, optional values, and value overrides, and attempts to render the Go templates.
 //
 // Render can be called repeatedly on the same engine.

--- a/pkg/lock/lock_manager.go
+++ b/pkg/lock/lock_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/werf/common-go/pkg/locker_with_retry"
 	"github.com/werf/lockgate"
 	"github.com/werf/lockgate/pkg/distributed_locker"
+	"github.com/werf/nelm/pkg/common"
 	"github.com/werf/nelm/pkg/kube"
 	"github.com/werf/nelm/pkg/log"
 	"github.com/werf/nelm/pkg/resource/spec"
@@ -22,16 +23,14 @@ type LockManager struct {
 }
 
 func NewLockManager(ctx context.Context, namespace string, createNamespace bool, clientFactory kube.ClientFactorier) (*LockManager, error) {
-	configMapName := "werf-synchronization"
-
 	locker := distributed_locker.NewKubernetesLocker(
 		clientFactory.Dynamic(), schema.GroupVersionResource{
 			Group:    "",
 			Version:  "v1",
 			Resource: "configmaps",
-		}, configMapName, namespace,
+		}, common.LockConfigMapName, namespace,
 	)
-	cmLocker := NewConfigMapLocker(configMapName, namespace, namespace, locker, clientFactory, ConfigMapLockerOptions{CreateNamespace: createNamespace})
+	cmLocker := NewConfigMapLocker(common.LockConfigMapName, namespace, namespace, locker, clientFactory, ConfigMapLockerOptions{CreateNamespace: createNamespace})
 	lockerWithRetry := locker_with_retry.NewLockerWithRetry(ctx, cmLocker, locker_with_retry.LockerWithRetryOptions{
 		MaxAcquireAttempts: 10,
 		MaxReleaseAttempts: 10,

--- a/pkg/util/manifest.go
+++ b/pkg/util/manifest.go
@@ -44,3 +44,29 @@ func SplitManifests(bigFile string) []string {
 
 	return result
 }
+
+func SplitManifestsKeepingEmpty(bigFile string) []string {
+	const sep = "\n---"
+
+	var result []string
+	for _, d := range strings.SplitAfter(bigFile, sep) {
+		d = strings.TrimSuffix(d, sep)
+
+		hasContent := false
+		for _, line := range strings.Split(d, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" && trimmed != "---" && !strings.HasPrefix(trimmed, "#") {
+				hasContent = true
+				break
+			}
+		}
+
+		if hasContent {
+			result = append(result, strings.TrimSpace(d)+"\n")
+		} else {
+			result = append(result, "")
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
Cherry-picks two flags from main into the 2 line so that werf 3 can use them
(werf 3 pins nelm from branch 2, where these options don't exist yet).

- a984242e — `--lookup-resources` / `LocalLookupResourcesPaths` (#657)
- 3d389efe — `--no-create-namespace` / `NoCreateNamespace` (#662)

`task build` and `task test:unit` are green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

