### PR TITLE
feat: add LintMode in chart render options and pass it to the Helm engine

### DIFF
--- a/pkg/action/chart_render.go
+++ b/pkg/action/chart_render.go
@@ -280,6 +280,7 @@ func ChartRender(ctx context.Context, opts ChartRenderOptions) (*ChartRenderResu
 		ChartVersion:               opts.ChartVersion,
 		ExtraAPIVersions:           opts.ExtraAPIVersions,
 		HelmOptions:                helmOptions,
+		LintMode:                   opts.LintMode,
 		LocalKubeVersion:           opts.LocalKubeVersion,
 		LocalLookupResourcesPaths:  opts.LocalLookupResourcesPaths,
 		Remote:                     opts.Remote,

--- a/pkg/action/chart_render.go
+++ b/pkg/action/chart_render.go
@@ -88,6 +88,10 @@ type ChartRenderOptions struct {
 	// LegacyLogRegistryStreamOut is the output writer for Helm registry client logs.
 	// Defaults to io.Discard if not set. Used for debugging registry operations.
 	LegacyLogRegistryStreamOut io.Writer
+	// LintMode renders templates leniently: missing `required` values and
+	// `fail` calls produce warnings instead of errors, and recoverable
+	// template execution errors yield partially rendered output.
+	LintMode bool
 	// LocalKubeVersion specifies the Kubernetes version to use for template rendering when not connected to a cluster.
 	// Format: "major.minor.patch" (e.g., "1.28.0"). Defaults to DefaultLocalKubeVersion if not set.
 	LocalKubeVersion string

--- a/pkg/chart/chart_render.go
+++ b/pkg/chart/chart_render.go
@@ -54,6 +54,7 @@ type RenderChartOptions struct {
 	ExtraAPIVersions          []string
 	HelmOptions               helmopts.HelmOptions
 	IgnoreBundleJS            bool
+	LintMode                  bool
 	LocalKubeVersion          string
 	LocalLookupResourcesPaths []string
 	NoStandaloneCRDs          bool
@@ -212,6 +213,7 @@ func RenderChart(ctx context.Context, chartPath, releaseName, releaseNamespace s
 	}
 
 	engine.EnableDNS = opts.TemplatesAllowDNS
+	engine.LintMode = opts.LintMode
 
 	log.Default.Debug(ctx, "Rendering resources for chart at %q", chartPath)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

