### PR TITLE
fix: repair ai lookup tests after helm fork api changes

### DIFF
--- a/pkg/chart/lookup_ai_test.go
+++ b/pkg/chart/lookup_ai_test.go
@@ -3,33 +3,34 @@
 package chart
 
 import (
+	"context"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	helmchart "github.com/werf/nelm/pkg/helm/pkg/chart"
-	"github.com/werf/nelm/pkg/helm/pkg/chartutil"
-	"github.com/werf/nelm/pkg/helm/pkg/engine"
-	"github.com/werf/nelm/pkg/helm/pkg/werf/helmopts"
+	chartcommon "github.com/werf/nelm/pkg/helm/pkg/chart/common"
+	chartcommonutil "github.com/werf/nelm/pkg/helm/pkg/chart/common/util"
+	v2chart "github.com/werf/nelm/pkg/helm/pkg/chart/v2"
+	helmengine "github.com/werf/nelm/pkg/helm/pkg/engine"
 )
 
 func TestAI_LocalClientProviderEmpty(t *testing.T) {
 	provider := newLocalClientProvider(nil)
 
-	c := &helmchart.Chart{
-		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
-		Templates: []*helmchart.File{
+	c := &v2chart.Chart{
+		Metadata: &v2chart.Metadata{Name: "moby", Version: "1.2.3"},
+		Templates: []*chartcommon.File{
 			{Name: "templates/empty", Data: []byte(`{{ (lookup "v1" "Pod" "default" "pod1") }}`)},
 		},
 		Values: map[string]any{},
 	}
 
-	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	vals, err := chartcommonutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
 	require.NoError(t, err)
 
-	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	out, err := helmengine.RenderWithClientProvider(context.Background(), c, vals, provider)
 	require.NoError(t, err)
 	require.Equal(t, "map[]", out["moby/templates/empty"])
 }
@@ -57,22 +58,22 @@ func TestAI_LocalClientProviderLookup(t *testing.T) {
 		"missing-get":     "map[]",
 	}
 
-	c := &helmchart.Chart{
-		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
+	c := &v2chart.Chart{
+		Metadata: &v2chart.Metadata{Name: "moby", Version: "1.2.3"},
 		Values:   map[string]any{},
 	}
 
 	for name, tpl := range templates {
-		c.Templates = append(c.Templates, &helmchart.File{
+		c.Templates = append(c.Templates, &chartcommon.File{
 			Name: path.Join("templates", name),
 			Data: []byte(tpl),
 		})
 	}
 
-	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	vals, err := chartcommonutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
 	require.NoError(t, err)
 
-	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	out, err := helmengine.RenderWithClientProvider(context.Background(), c, vals, provider)
 	require.NoError(t, err)
 
 	for name, want := range expected {
@@ -96,22 +97,22 @@ func TestAI_LocalClientProviderNamespaceIsolation(t *testing.T) {
 		"other-ns-get": "map[]",
 	}
 
-	c := &helmchart.Chart{
-		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
+	c := &v2chart.Chart{
+		Metadata: &v2chart.Metadata{Name: "moby", Version: "1.2.3"},
 		Values:   map[string]any{},
 	}
 
 	for name, tpl := range templates {
-		c.Templates = append(c.Templates, &helmchart.File{
+		c.Templates = append(c.Templates, &chartcommon.File{
 			Name: path.Join("templates", name),
 			Data: []byte(tpl),
 		})
 	}
 
-	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	vals, err := chartcommonutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
 	require.NoError(t, err)
 
-	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	out, err := helmengine.RenderWithClientProvider(context.Background(), c, vals, provider)
 	require.NoError(t, err)
 
 	for name, want := range expected {
@@ -124,18 +125,18 @@ func TestAI_LocalClientProviderNamespaceIsolation(t *testing.T) {
 func TestAI_LocalClientProviderUnstubbedListEmptyProvider(t *testing.T) {
 	provider := newLocalClientProvider(nil)
 
-	c := &helmchart.Chart{
-		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
-		Templates: []*helmchart.File{
+	c := &v2chart.Chart{
+		Metadata: &v2chart.Metadata{Name: "moby", Version: "1.2.3"},
+		Templates: []*chartcommon.File{
 			{Name: "templates/list", Data: []byte(`{{ (lookup "v1" "Pod" "" "").items | len }}`)},
 		},
 		Values: map[string]any{},
 	}
 
-	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	vals, err := chartcommonutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
 	require.NoError(t, err)
 
-	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	out, err := helmengine.RenderWithClientProvider(context.Background(), c, vals, provider)
 	require.NoError(t, err)
 	require.Equal(t, "0", out["moby/templates/list"])
 }
@@ -145,18 +146,18 @@ func TestAI_LocalClientProviderUnstubbedListOtherKind(t *testing.T) {
 		makeUnstructured("v1", "Pod", "pod1", "default"),
 	})
 
-	c := &helmchart.Chart{
-		Metadata: &helmchart.Metadata{Name: "moby", Version: "1.2.3"},
-		Templates: []*helmchart.File{
+	c := &v2chart.Chart{
+		Metadata: &v2chart.Metadata{Name: "moby", Version: "1.2.3"},
+		Templates: []*chartcommon.File{
 			{Name: "templates/list", Data: []byte(`{{ (lookup "v1" "ConfigMap" "" "").items | len }}`)},
 		},
 		Values: map[string]any{},
 	}
 
-	vals, err := chartutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
+	vals, err := chartcommonutil.CoalesceValues(c, map[string]any{"Values": map[string]any{}})
 	require.NoError(t, err)
 
-	out, err := engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})
+	out, err := helmengine.RenderWithClientProvider(context.Background(), c, vals, provider)
 	require.NoError(t, err)
 	require.Equal(t, "0", out["moby/templates/list"])
 }


### PR DESCRIPTION
## Summary

Updates `pkg/chart/lookup_ai_test.go` to the current vendored Helm fork API so it compiles again. Test-only change: the five `TestAI_LocalClientProvider*` cases keep their templates, expected values and assertions — only imports, types and the render call site move to their new homes.

## Why

The file was written against an older layout of `pkg/helm` and had gone stale, so the package failed to build:

```
pkg/chart/lookup_ai_test.go:11:2: no required module provides package
  github.com/werf/nelm/pkg/helm/pkg/chartutil
```

Three upstream-sync changes broke it:

- `pkg/helm/pkg/chartutil` is gone — `CoalesceValues` now lives in `pkg/helm/pkg/chart/common/util` (`chart/common/util/coalesce.go:49`).
- `pkg/helm/pkg/werf/helmopts` was removed outright; this test was the last reference to it anywhere in the repo.
- `engine.RenderWithClientProvider` (`pkg/helm/pkg/engine/engine.go:124`) now takes `context.Context` first and no longer takes a `helmopts.HelmOptions` argument.

## Key changes

**`pkg/chart/lookup_ai_test.go`**

- `chartutil.CoalesceValues` → `chartcommonutil.CoalesceValues` (`pkg/helm/pkg/chart/common/util`).
- `engine.RenderWithClientProvider(c, vals, provider, helmopts.HelmOptions{})` → `helmengine.RenderWithClientProvider(context.Background(), c, vals, provider)`, in all five tests.
- Chart templates retyped from a chart-package-local `File` to `chartcommon.File`, which is what `v2chart.Chart.Templates` is declared as (`pkg/helm/pkg/chart/v2/chart.go:51`); chart literals now use `v2chart.Chart` / `v2chart.Metadata`.
- Import aliases aligned with `pkg/chart/chart_render.go` (`v2chart`, `chartcommon`, `chartcommonutil`, `helmengine`).
- Restored the `//go:build ai_tests` tag, which had been dropped in the working tree. It matches the two sibling `*_ai_test.go` files in the package and the AGENTS.md rule for AI-written tests.

No production code is touched, and `go mod tidy` is a no-op — every import moved within this module.

## Verification

```
task test:go-test paths="./pkg/chart" tags=ai_tests -- -run TestAI_LocalClientProvider -v
```

All 5 tests and 7 subtests pass. `task lint:golangci-lint paths="./pkg/chart/..." tags=ai_tests` reports no new findings.

## Review focus / risks

- Low risk overall — test-only, and `pkg/helm/pkg/engine/engine_test.go:295-395` exercises the same render path with the same expectations, which is the reference for why the untouched assertions (including the `moby/templates/<name>` output keys) remain valid.
- Confirm the build tag should stay on. With `//go:build ai_tests` restored, these tests do **not** run in the default `task test:unit`, so a future API break here goes unnoticed until someone runs with the tag. That is the existing convention for `*_ai_test.go`, but it is the one judgement call in this PR.
- Pre-existing lint findings left alone as out of scope: `testpackage` fires on all three `*_ai_test.go` files in `pkg/chart` (they test unexported symbols such as `newLocalClientProvider`, so `chart_test` is not an option), and a `wsl_v5` whitespace complaint sits in the already-committed `pkg/chart/chart_render.go:376`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

