### PR TITLE
fix: optimize validations args

### DIFF
--- a/cmd/nelm/common_flags.go
+++ b/cmd/nelm/common_flags.go
@@ -351,13 +351,6 @@ func AddResourceValidationFlags(cmd *cobra.Command, cfg *common.ResourceValidati
 		return fmt.Errorf("add flag: %w", err)
 	}
 
-	if err := cli.AddFlag(cmd, &cfg.LocalResourceValidation, "local-resource-validation", false, "Do not use external json schema sources, validate against the json schemas embedded into the binary instead", cli.AddFlagOptions{
-		GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
-		Group:                resourceValidationGroup,
-	}); err != nil {
-		return fmt.Errorf("add flag: %w", err)
-	}
-
 	if err := cli.AddFlag(cmd, &cfg.ValidationSkip, "resource-validation-skip", []string{}, "Skip resource validation for resources with specified attributes. Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, namespace. Example: kind=Deployment,name=my-app", cli.AddFlagOptions{
 		GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
 		Group:                resourceValidationGroup,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -264,10 +264,6 @@ nelm release install [options...] -n namespace -r release [chart-dir|chart-repo-
 
 **Resource validation options:**
 
-- `--local-resource-validation` (default: `false`)
-
-  Do not use external json schema sources, validate against the json schemas embedded into the binary instead\. Vars: \$NELM\_LOCAL\_RESOURCE\_VALIDATION, \$NELM\_RELEASE\_INSTALL\_LOCAL\_RESOURCE\_VALIDATION
-
 - `--no-resource-validation` (default: `false`)
 
   Disable resource validation\. Vars: \$NELM\_NO\_RESOURCE\_VALIDATION, \$NELM\_RELEASE\_INSTALL\_NO\_RESOURCE\_VALIDATION
@@ -620,10 +616,6 @@ nelm release rollback [options...] -n namespace -r release [revision]
 
 
 **Resource validation options:**
-
-- `--local-resource-validation` (default: `false`)
-
-  Do not use external json schema sources, validate against the json schemas embedded into the binary instead\. Vars: \$NELM\_LOCAL\_RESOURCE\_VALIDATION, \$NELM\_RELEASE\_ROLLBACK\_LOCAL\_RESOURCE\_VALIDATION
 
 - `--no-resource-validation` (default: `false`)
 
@@ -989,10 +981,6 @@ nelm release plan install [options...] -n namespace -r release [chart-dir|chart-
 
 
 **Resource validation options:**
-
-- `--local-resource-validation` (default: `false`)
-
-  Do not use external json schema sources, validate against the json schemas embedded into the binary instead\. Vars: \$NELM\_LOCAL\_RESOURCE\_VALIDATION, \$NELM\_RELEASE\_PLAN\_INSTALL\_LOCAL\_RESOURCE\_VALIDATION
 
 - `--no-resource-validation` (default: `false`)
 
@@ -2158,10 +2146,6 @@ nelm chart lint [options...] [chart-dir|chart-repo-name/chart-name|chart-archive
 
 
 **Resource validation options:**
-
-- `--local-resource-validation` (default: `false`)
-
-  Do not use external json schema sources, validate against the json schemas embedded into the binary instead\. Vars: \$NELM\_LOCAL\_RESOURCE\_VALIDATION, \$NELM\_CHART\_LINT\_LOCAL\_RESOURCE\_VALIDATION
 
 - `--no-resource-validation` (default: `false`)
 

--- a/pkg/common/options.go
+++ b/pkg/common/options.go
@@ -222,8 +222,6 @@ type ResourceValidationOptions struct {
 	NoResourceValidation bool `json:"noResourceValidation"`
 	// NoValuesSchemaValidation disables values validation against json schema.
 	NoValuesSchemaValidation bool `json:"noValuesSchemaValidation"`
-	// LocalResourceValidation validates by using kubeconform embedded schemas and client-go codec only.
-	LocalResourceValidation bool `json:"localResourceValidation"`
 	// ValidationSkip Do not validate resources with specific attributes.
 	ValidationSkip []string `json:"validationSkip"`
 	// ValidationSchemaCacheLifetime how long the schema cache should be valid.

--- a/pkg/resource/kubeconform.go
+++ b/pkg/resource/kubeconform.go
@@ -44,7 +44,7 @@ type kubeConformValidator struct {
 	validators          []*kubeConformInstance
 }
 
-func newKubeConformValidator(schemaCacheLifetime time.Duration, schemaSources []string, embeddedSchemasOnly bool) (*kubeConformValidator, error) {
+func newKubeConformValidator(schemaCacheLifetime time.Duration, schemaSources []string) (*kubeConformValidator, error) {
 	kubernetesSource, err := schemas.KubernetesSource()
 	if err != nil {
 		return nil, fmt.Errorf("get embedded Kubernetes schemas: %w", err)
@@ -53,10 +53,6 @@ func newKubeConformValidator(schemaCacheLifetime time.Duration, schemaSources []
 	crdsSource, err := schemas.CRDsSource()
 	if err != nil {
 		return nil, fmt.Errorf("get embedded CRD schemas: %w", err)
-	}
-
-	if embeddedSchemasOnly {
-		schemaSources = nil
 	}
 
 	cacheSubDirName := getHash(strings.Join(schemaSources, "-"))

--- a/pkg/resource/validate.go
+++ b/pkg/resource/validate.go
@@ -45,7 +45,7 @@ func validateResourceSchemas(ctx context.Context, releaseNamespace string, resou
 	kubeConformValidator, err := newKubeConformValidator(
 		opts.ValidationSchemaCacheLifetime,
 		opts.ValidationExtraSchemas,
-		opts.LocalResourceValidation)
+	)
 	if err != nil {
 		return fmt.Errorf("get schema validator: %w", err)
 	}


### PR DESCRIPTION
## Summary

Removes the `--local-resource-validation` flag together with its
`ResourceValidationOptions.LocalResourceValidation` option and the plumbing that
carried it into the kubeconform validator. Embedded-schemas-only validation is
still fully reachable — it is now simply the default, achieved by not passing
`--resource-validation-extra-schema`.

## Why

After the validation schemas were embedded into the binary
(`f6ce79b3f feat: embed kubeconform validation schemas into the binary`),
external schema sources became strictly opt-in: `ValidationExtraSchemas` defaults
to an empty list and the embedded Kubernetes/CRD sources are always appended in
`newKubeConformValidator`. That made `--local-resource-validation` a no-op in the
default case and merely an override that nulls out whatever the user explicitly
asked for — the flag's only effect was `schemaSources = nil`, which duplicates
"don't pass extra schemas". Dropping it removes a redundant knob from the CLI
surface before it ships.

## Key changes

**CLI surface** — `cmd/nelm/common_flags.go`
- Drops the `--local-resource-validation` flag registration from
  `AddResourceValidationFlags`, along with its global/local env var bindings.

**Public options** — `pkg/common/options.go`
- Removes the `LocalResourceValidation bool` field (`json:"localResourceValidation"`)
  from `ResourceValidationOptions`.

**Validator** — `pkg/resource/kubeconform.go`, `pkg/resource/validate.go`
- `newKubeConformValidator` loses its `embeddedSchemasOnly` parameter and the
  `schemaSources = nil` short-circuit; it now always honors the caller-supplied
  sources plus the embedded ones.
- `validateResourceSchemas` updated to the two-argument signature.

## Review focus / risks

- **Breaking change to the exported API.** `ResourceValidationOptions` is part of
  `pkg/common`, and `newKubeConformValidator`'s signature changed. Confirm no
  downstream consumer (werf in particular) sets `LocalResourceValidation` or
  serializes/deserializes `localResourceValidation` in a persisted options
  payload — the JSON tag disappearing means any stored value is now silently
  ignored rather than rejected.
- **Behavior change for anyone combining the two flags.** Previously
  `--resource-validation-extra-schema <src> --local-resource-validation` ignored
  `<src>` and validated offline; now the extra source is used, which means
  network access where there was none. Verify that's the intended semantics and
  that no docs/README/e2e invocation relies on the old combination.
- **Cache key.** `cacheSubDirName` is derived from the joined `schemaSources`.
  With the flag gone the hash no longer depends on the (removed) offline mode, so
  a cache directory populated by an older binary run with
  `--local-resource-validation` plus extra schemas will now be reused under the
  same key with different effective sources. Worth confirming the
  `--resource-validation-cache-lifetime` expiry is
- Since the flag was only introduced on this release line and never released,
  double-check whether a changelog/migration note i

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

