### PR TITLE
fix(helm): serialize action configuration initialization

### DIFF
--- a/pkg/helm/pkg/action/action.go
+++ b/pkg/helm/pkg/action/action.go
@@ -663,6 +663,9 @@ func (cfg *Configuration) recordRelease(r *release.Release) {
 
 // Init initializes the action configuration
 func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string) error {
+	cfg.mutex.Lock()
+	defer cfg.mutex.Unlock()
+
 	kc := kube.New(getter)
 	kc.SetLogger(cfg.Logger().Handler())
 

--- a/pkg/helm/pkg/action/configuration_ai_test.go
+++ b/pkg/helm/pkg/action/configuration_ai_test.go
@@ -1,0 +1,34 @@
+//go:build ai_tests
+
+package action
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestAIConfigurationInitConcurrent(t *testing.T) {
+	cfg := NewConfiguration()
+	getter := genericclioptions.NewConfigFlags(true)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			errs <- cfg.Init(getter, "default", "memory")
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.NotNil(t, cfg.Releases)
+}


### PR DESCRIPTION
## Summary

Concurrent Helm command initialization can mutate one shared `action.Configuration` at the same time. `Configuration.Init` now serializes these updates on the Nelm `2` branch used by werf `3`.

## What

- `Configuration.Init` protects client, storage, and hook-output replacement with its existing configuration-local lock.
- AI regression test starts two concurrent memory-driver initializations of one configuration.
- VERIFIED: `task --yes test:ginkgo paths="./pkg/helm/pkg/action" tags="ai_tests" parallel=false -- --race` passes.

## Why

Race-instrumented werf e2e compose testing reported concurrent writes at `Configuration.Init` while Helm commands initialized the same configuration. This caused werf to exit with code 66.

Tracked in werf/werf#7775.