### PR TITLE
fix: prevent concurrent Helm configuration races

### DIFF
--- a/pkg/helm/pkg/action/action.go
+++ b/pkg/helm/pkg/action/action.go
@@ -724,6 +724,9 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 
 // SetHookOutputFunc sets the HookOutputFunc on the Configuration.
 func (cfg *Configuration) SetHookOutputFunc(hookOutputFunc func(_, _, _ string) io.Writer) {
+	cfg.mutex.Lock()
+	defer cfg.mutex.Unlock()
+
 	cfg.HookOutputFunc = hookOutputFunc
 }
 

--- a/pkg/helm/pkg/action/configuration_ai_test.go
+++ b/pkg/helm/pkg/action/configuration_ai_test.go
@@ -3,6 +3,7 @@
 package action
 
 import (
+	"io"
 	"sync"
 	"testing"
 
@@ -10,25 +11,29 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func TestAIConfigurationInitConcurrent(t *testing.T) {
+func TestAIConfigurationInitAndSetHookOutputFuncConcurrent(t *testing.T) {
 	cfg := NewConfiguration()
 	getter := genericclioptions.NewConfigFlags(true)
-	errs := make(chan error, 2)
+	start := make(chan struct{})
+	errs := make(chan error, 1)
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	for range 2 {
-		go func() {
-			defer wg.Done()
-			errs <- cfg.Init(getter, "default", "memory")
-		}()
-	}
+	go func() {
+		defer wg.Done()
+		<-start
+		errs <- cfg.Init(getter, "default", "memory")
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		cfg.SetHookOutputFunc(func(_, _, _ string) io.Writer { return io.Discard })
+	}()
 
+	close(start)
 	wg.Wait()
-	close(errs)
 
-	for err := range errs {
-		require.NoError(t, err)
-	}
+	require.NoError(t, <-errs)
 	require.NotNil(t, cfg.Releases)
+	require.NotNil(t, cfg.HookOutputFunc)
 }


### PR DESCRIPTION
## Summary

Concurrent Helm commands sharing one action configuration no longer race while initializing its hook output. Race-instrumented callers no longer exit with Go race-detector status 66 from this conflict.

## What

- Concurrent `Configuration.Init` and `Configuration.SetHookOutputFunc` calls serialize writes to `HookOutputFunc` with the configuration mutex.
- No Helm CLI surface or normal command behavior changes.
- VERIFIED: remote Linux `CGO_ENABLED=1 task --yes test:ginkgo paths='./pkg/helm/pkg/action' tags='ai_tests' parallel=false -- --race` passes.

## Why

#686 locked `Configuration.Init`, but `SetHookOutputFunc` still wrote `HookOutputFunc` without that lock. Parallel command initialization therefore retained one unsynchronized write pair; using the existing configuration mutex closes that pair.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

