### PR TITLE
fix: prevent progress printer race

### DIFF
--- a/pkg/track/progress_tables.go
+++ b/pkg/track/progress_tables.go
@@ -35,10 +35,10 @@ func NewProgressTablesPrinter(taskStore *kdutil.Concurrent[*statestore.TaskStore
 }
 
 func (p *ProgressTablesPrinter) Start(ctx context.Context, interval time.Duration) {
-	go func() {
-		p.finishedCh = make(chan struct{})
+	p.finishedCh = make(chan struct{})
+	ctx, p.ctxCancelFn = context.WithCancelCause(ctx)
 
-		ctx, p.ctxCancelFn = context.WithCancelCause(ctx)
+	go func() {
 		defer func() {
 			p.ctxCancelFn(fmt.Errorf("context canceled: table printer finished"))
 

--- a/pkg/track/progress_tables_ai_test.go
+++ b/pkg/track/progress_tables_ai_test.go
@@ -1,0 +1,33 @@
+//go:build ai_tests
+
+package track
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/werf/kubedog/pkg/dyntracker/logstore"
+	"github.com/werf/kubedog/pkg/dyntracker/statestore"
+	kdutil "github.com/werf/kubedog/pkg/dyntracker/util"
+	"github.com/werf/logboek"
+)
+
+func TestAIProgressTablesPrinterStartInitializesBeforeReturn(t *testing.T) {
+	printer := NewProgressTablesPrinter(
+		kdutil.NewConcurrent(statestore.NewTaskStore()),
+		kdutil.NewConcurrent(logstore.NewLogStore()),
+		ProgressTablesPrinterOptions{},
+	)
+
+	ctx := logboek.NewContext(context.Background(), logboek.NewLogger(io.Discard, io.Discard))
+	printer.Start(ctx, time.Hour)
+	require.NotNil(t, printer.ctxCancelFn)
+	require.NotNil(t, printer.finishedCh)
+
+	printer.Stop()
+	printer.Wait()
+}


### PR DESCRIPTION
Progress-table printer initialization now completes before its worker goroutine starts. Callers can immediately stop and wait for a printer without concurrently reading state the worker is still assigning.

The race was reported by werf race CI during release uninstall: `ProgressTablesPrinter.Stop` read the cancellation function while `Start` assigned it in the worker goroutine.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

