### PR TITLE
feat: add `renderPatches` support for --patches/patches.yaml

### DIFF
--- a/cmd/nelm/chart_lint.go
+++ b/cmd/nelm/chart_lint.go
@@ -75,6 +75,10 @@ func newChartLintCommand(ctx context.Context, afterAllCommandsBuiltFuncs map[*co
 			return fmt.Errorf("add secret values flags: %w", err)
 		}
 
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+			return fmt.Errorf("add patches flags: %w", err)
+		}
+
 		if err := cli.AddFlag(cmd, &cfg.ChartAppVersion, "app-version", "", "Set appVersion of Chart.yaml", cli.AddFlagOptions{
 			GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
 			Group:                patchFlagGroup,

--- a/cmd/nelm/chart_lint.go
+++ b/cmd/nelm/chart_lint.go
@@ -75,7 +75,7 @@ func newChartLintCommand(ctx context.Context, afterAllCommandsBuiltFuncs map[*co
 			return fmt.Errorf("add secret values flags: %w", err)
 		}
 
-		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable, AddPatchesFlagsOptions{}); err != nil {
 			return fmt.Errorf("add patches flags: %w", err)
 		}
 

--- a/cmd/nelm/chart_render.go
+++ b/cmd/nelm/chart_render.go
@@ -74,7 +74,7 @@ func newChartRenderCommand(ctx context.Context, afterAllCommandsBuiltFuncs map[*
 			return fmt.Errorf("add secret values flags: %w", err)
 		}
 
-		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable, AddPatchesFlagsOptions{}); err != nil {
 			return fmt.Errorf("add patches flags: %w", err)
 		}
 

--- a/cmd/nelm/chart_render.go
+++ b/cmd/nelm/chart_render.go
@@ -74,6 +74,10 @@ func newChartRenderCommand(ctx context.Context, afterAllCommandsBuiltFuncs map[*
 			return fmt.Errorf("add secret values flags: %w", err)
 		}
 
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+			return fmt.Errorf("add patches flags: %w", err)
+		}
+
 		if err := cli.AddFlag(cmd, &cfg.NoValuesSchemaValidation, "no-values-schema-validation", false, "Disable values validation against JSON schema", cli.AddFlagOptions{
 			GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
 			Group:                resourceValidationGroup,

--- a/cmd/nelm/common_flags.go
+++ b/cmd/nelm/common_flags.go
@@ -3,11 +3,17 @@ package main
 import (
 	"fmt"
 
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	"github.com/werf/common-go/pkg/cli"
 	"github.com/werf/nelm/pkg/common"
 )
+
+type AddPatchesFlagsOptions struct {
+	// NoRender marks a command that renders nothing, so render patches have no effect.
+	NoRender bool
+}
 
 func AddChartRepoConnectionFlags(cmd *cobra.Command, cfg *common.ChartRepoConnectionOptions) error {
 	if err := cli.AddFlag(cmd, &cfg.ChartRepoBasicAuthPassword, "chart-repo-basic-password", "", "Basic auth password to authenticate in chart repository", cli.AddFlagOptions{
@@ -317,8 +323,14 @@ func AddKubeConnectionFlags(cmd *cobra.Command, cfg *common.KubeConnectionOption
 	return nil
 }
 
-func AddPatchesFlags(cmd *cobra.Command, patchesFiles *[]string, defaultPatchesDisable *bool) error {
-	if err := cli.AddFlag(cmd, patchesFiles, "patches", []string{}, "Additional patches files (render patches and diff patches for drift detection)", cli.AddFlagOptions{
+func AddPatchesFlags(cmd *cobra.Command, patchesFiles *[]string, defaultPatchesDisable *bool, opts AddPatchesFlagsOptions) error {
+	description := lo.Ternary(
+		opts.NoRender,
+		"Additional patches files (diff patches for drift detection)",
+		"Additional patches files (render patches for rendered resources, diff patches for drift detection)",
+	)
+
+	if err := cli.AddFlag(cmd, patchesFiles, "patches", []string{}, description, cli.AddFlagOptions{
 		GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
 		Group:                patchFlagGroup,
 		Type:                 cli.FlagTypeFile,

--- a/cmd/nelm/common_flags.go
+++ b/cmd/nelm/common_flags.go
@@ -318,7 +318,7 @@ func AddKubeConnectionFlags(cmd *cobra.Command, cfg *common.KubeConnectionOption
 }
 
 func AddPatchesFlags(cmd *cobra.Command, patchesFiles *[]string, defaultPatchesDisable *bool) error {
-	if err := cli.AddFlag(cmd, patchesFiles, "patches", []string{}, "Additional patches files (diff patches for drift detection)", cli.AddFlagOptions{
+	if err := cli.AddFlag(cmd, patchesFiles, "patches", []string{}, "Additional patches files (render patches and diff patches for drift detection)", cli.AddFlagOptions{
 		GetEnvVarRegexesFunc: cli.GetFlagGlobalAndLocalEnvVarRegexes,
 		Group:                patchFlagGroup,
 		Type:                 cli.FlagTypeFile,

--- a/cmd/nelm/release_install.go
+++ b/cmd/nelm/release_install.go
@@ -77,7 +77,7 @@ func newReleaseInstallCommand(ctx context.Context, afterAllCommandsBuiltFuncs ma
 			return fmt.Errorf("add secret values flags: %w", err)
 		}
 
-		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable, AddPatchesFlagsOptions{}); err != nil {
 			return fmt.Errorf("add patches flags: %w", err)
 		}
 

--- a/cmd/nelm/release_plan_install.go
+++ b/cmd/nelm/release_plan_install.go
@@ -77,7 +77,7 @@ func newReleasePlanInstallCommand(ctx context.Context, afterAllCommandsBuiltFunc
 			return fmt.Errorf("add secret values flags: %w", err)
 		}
 
-		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable, AddPatchesFlagsOptions{}); err != nil {
 			return fmt.Errorf("add patches flags: %w", err)
 		}
 

--- a/cmd/nelm/release_rollback.go
+++ b/cmd/nelm/release_rollback.go
@@ -65,7 +65,7 @@ func newReleaseRollbackCommand(ctx context.Context, afterAllCommandsBuiltFuncs m
 			return fmt.Errorf("add tracking flags: %w", err)
 		}
 
-		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable, AddPatchesFlagsOptions{NoRender: true}); err != nil {
 			return fmt.Errorf("add patches flags: %w", err)
 		}
 

--- a/cmd/nelm/release_uninstall.go
+++ b/cmd/nelm/release_uninstall.go
@@ -53,7 +53,7 @@ func newReleaseUninstallCommand(ctx context.Context, afterAllCommandsBuiltFuncs 
 			return fmt.Errorf("add tracking flags: %w", err)
 		}
 
-		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable); err != nil {
+		if err := AddPatchesFlags(cmd, &cfg.PatchesFiles, &cfg.DefaultPatchesDisable, AddPatchesFlagsOptions{NoRender: true}); err != nil {
 			return fmt.Errorf("add patches flags: %w", err)
 		}
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -306,7 +306,7 @@ nelm release install [options...] -n namespace -r release [chart-dir|chart-repo-
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_INSTALL\_PATCHES
+  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_INSTALL\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 
@@ -647,7 +647,7 @@ nelm release rollback [options...] -n namespace -r release [revision]
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_ROLLBACK\_PATCHES
+  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_ROLLBACK\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 
@@ -1024,7 +1024,7 @@ nelm release plan install [options...] -n namespace -r release [chart-dir|chart-
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_PLAN\_INSTALL\_PATCHES
+  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_PLAN\_INSTALL\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 
@@ -1302,7 +1302,7 @@ nelm release uninstall [options...] -n namespace -r release
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_UNINSTALL\_PATCHES
+  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_UNINSTALL\_PATCHES
 
 
 **Progress options:**
@@ -2183,6 +2183,14 @@ nelm chart lint [options...] [chart-dir|chart-repo-name/chart-name|chart-archive
 
   Add labels to all resources\. Vars: \$NELM\_LABELS\_\*, \$NELM\_CHART\_LINT\_LABELS\_\*
 
+- `--no-default-patches` (default: `false`)
+
+  Ignore patches\.yaml of the top\-level chart and subcharts\. Vars: \$NELM\_NO\_DEFAULT\_PATCHES, \$NELM\_CHART\_LINT\_NO\_DEFAULT\_PATCHES
+
+- `--patches` (default: `[]`)
+
+  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_CHART\_LINT\_PATCHES
+
 - `--runtime-annotations` (default: `{}`)
 
   Add annotations which will not trigger resource updates to all resources\. Vars: \$NELM\_RUNTIME\_ANNOTATIONS\_\*, \$NELM\_CHART\_LINT\_RUNTIME\_ANNOTATIONS\_\*
@@ -2545,6 +2553,14 @@ nelm chart render [options...] [chart-dir|chart-repo-name/chart-name|chart-archi
 - `--labels` (default: `{}`)
 
   Add labels to all resources\. Vars: \$NELM\_LABELS\_\*, \$NELM\_CHART\_RENDER\_LABELS\_\*
+
+- `--no-default-patches` (default: `false`)
+
+  Ignore patches\.yaml of the top\-level chart and subcharts\. Vars: \$NELM\_NO\_DEFAULT\_PATCHES, \$NELM\_CHART\_RENDER\_NO\_DEFAULT\_PATCHES
+
+- `--patches` (default: `[]`)
+
+  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_CHART\_RENDER\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -306,7 +306,7 @@ nelm release install [options...] -n namespace -r release [chart-dir|chart-repo-
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_INSTALL\_PATCHES
+  Additional patches files \(render patches for rendered resources, diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_INSTALL\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 
@@ -647,7 +647,7 @@ nelm release rollback [options...] -n namespace -r release [revision]
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_ROLLBACK\_PATCHES
+  Additional patches files \(diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_ROLLBACK\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 
@@ -1024,7 +1024,7 @@ nelm release plan install [options...] -n namespace -r release [chart-dir|chart-
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_PLAN\_INSTALL\_PATCHES
+  Additional patches files \(render patches for rendered resources, diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_PLAN\_INSTALL\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 
@@ -1302,7 +1302,7 @@ nelm release uninstall [options...] -n namespace -r release
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_UNINSTALL\_PATCHES
+  Additional patches files \(diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_RELEASE\_UNINSTALL\_PATCHES
 
 
 **Progress options:**
@@ -2189,7 +2189,7 @@ nelm chart lint [options...] [chart-dir|chart-repo-name/chart-name|chart-archive
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_CHART\_LINT\_PATCHES
+  Additional patches files \(render patches for rendered resources, diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_CHART\_LINT\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 
@@ -2560,7 +2560,7 @@ nelm chart render [options...] [chart-dir|chart-repo-name/chart-name|chart-archi
 
 - `--patches` (default: `[]`)
 
-  Additional patches files \(render patches and diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_CHART\_RENDER\_PATCHES
+  Additional patches files \(render patches for rendered resources, diff patches for drift detection\)\. Vars: \$NELM\_PATCHES, \$NELM\_CHART\_RENDER\_PATCHES
 
 - `--runtime-annotations` (default: `{}`)
 

--- a/pkg/action/chart_lint.go
+++ b/pkg/action/chart_lint.go
@@ -58,6 +58,9 @@ type ChartLintOptions struct {
 	DefaultChartVersion string
 	// DefaultDeletePropagation sets the deletion propagation policy for resource deletions.
 	DefaultDeletePropagation string
+	// DefaultPatchesDisable, when true, ignores chart-shipped patches.yaml files
+	// (from the top-level chart and subcharts).
+	DefaultPatchesDisable bool
 	// DenoBinaryPath, if specified, uses this path as the Deno binary instead of auto-downloading.
 	DenoBinaryPath string
 	// DockerConfig is the path to the Docker configuration directory (e.g., ~/.docker).
@@ -112,6 +115,11 @@ type ChartLintOptions struct {
 	// NoRemoveManualChanges, when true, preserves fields during validation that would be manually added.
 	// Used in the validation dry-run to check resource compatibility.
 	NoRemoveManualChanges bool
+	// PatchesFiles are paths to patches files (same format as a chart-shipped
+	// patches.yaml) whose rules are applied on top of chart-shipped ones. Rules from
+	// these files are UNSCOPED (they may match any resource), unlike chart-shipped
+	// rules which are scoped to their chart subtree.
+	PatchesFiles []string
 	// RegistryCredentialsPath is the path to Docker config.json file with registry credentials.
 	// Defaults to DockerConfig/config.json if not set.
 	// Used for authenticating to OCI registries when pulling charts.
@@ -284,6 +292,13 @@ func ChartLint(ctx context.Context, opts ChartLintOptions) error {
 		return fmt.Errorf("render chart: %w", err)
 	}
 
+	log.Default.Debug(ctx, "Resolve patches")
+
+	patches, err := resolvePatches(renderChartResult.Chart, opts.DefaultPatchesDisable, opts.PatchesFiles)
+	if err != nil {
+		return fmt.Errorf("resolve patches: %w", err)
+	}
+
 	log.Default.Debug(ctx, "Build transformed resource specs")
 
 	transformedResSpecs, err := spec.BuildTransformedResourceSpecs(ctx, opts.ReleaseNamespace, renderChartResult.ResourceSpecs, []spec.ResourceTransformer{
@@ -293,9 +308,16 @@ func ChartLint(ctx context.Context, opts ChartLintOptions) error {
 		return fmt.Errorf("build transformed resource specs: %w", err)
 	}
 
+	log.Default.Debug(ctx, "Build render patched resource specs")
+
+	renderPatchedResSpecs, err := spec.BuildRenderPatchedResourceSpecs(ctx, opts.ReleaseNamespace, transformedResSpecs, patches.Render)
+	if err != nil {
+		return fmt.Errorf("build render patched resource specs: %w", err)
+	}
+
 	log.Default.Debug(ctx, "Build releasable resource specs")
 
-	releasableResSpecs, err := spec.BuildPatchedResourceSpecs(ctx, opts.ReleaseNamespace, transformedResSpecs, []spec.ResourcePatcher{
+	releasableResSpecs, err := spec.BuildPatchedResourceSpecs(ctx, opts.ReleaseNamespace, renderPatchedResSpecs, []spec.ResourcePatcher{
 		spec.NewExtraMetadataPatcher(opts.ExtraAnnotations, opts.ExtraLabels),
 		spec.NewSecretStringDataPatcher(),
 	})
@@ -360,6 +382,7 @@ func ChartLint(ctx context.Context, opts ChartLintOptions) error {
 	}
 
 	instResInfos, delResInfos, err := plan.BuildResourceInfos(ctx, deployType, opts.ReleaseName, opts.ReleaseNamespace, instResources, delResources, prevReleaseFailed, clientFactory, plan.BuildResourceInfosOptions{
+		DiffPatches:                        patches.Diff,
 		NetworkParallelism:                 opts.NetworkParallelism,
 		NoRemoveManualChanges:              opts.NoRemoveManualChanges,
 		LastDeployedOrLastRelResourceSpecs: lastDeployedOrLastRelResSpecs,

--- a/pkg/action/chart_render.go
+++ b/pkg/action/chart_render.go
@@ -57,6 +57,9 @@ type ChartRenderOptions struct {
 	DefaultChartName string
 	// DefaultChartVersion sets the default chart version when Chart.yaml doesn't specify one.
 	DefaultChartVersion string
+	// DefaultPatchesDisable, when true, ignores chart-shipped patches.yaml files
+	// (from the top-level chart and subcharts).
+	DefaultPatchesDisable bool
 	// DenoBinaryPath, if specified, uses this path as the Deno binary instead of auto-downloading.
 	DenoBinaryPath string
 	// DockerConfig is the path to the Docker configuration directory (e.g., ~/.docker).
@@ -107,6 +110,11 @@ type ChartRenderOptions struct {
 	// OutputNoPrint, when true, suppresses printing the rendered manifests to stdout.
 	// Useful when only the result data structure is needed.
 	OutputNoPrint bool
+	// PatchesFiles are paths to patches files (same format as a chart-shipped
+	// patches.yaml) whose rules are applied on top of chart-shipped ones. Rules from
+	// these files are UNSCOPED (they may match any resource), unlike chart-shipped
+	// rules which are scoped to their chart subtree.
+	PatchesFiles []string
 	// RegistryCredentialsPath is the path to Docker config.json file with registry credentials.
 	// Defaults to DockerConfig/config.json if not set.
 	// Used for authenticating to OCI registries when pulling charts.
@@ -285,6 +293,13 @@ func ChartRender(ctx context.Context, opts ChartRenderOptions) (*ChartRenderResu
 		return nil, fmt.Errorf("render chart: %w", err)
 	}
 
+	log.Default.Debug(ctx, "Resolve patches")
+
+	patches, err := resolvePatches(renderChartResult.Chart, opts.DefaultPatchesDisable, opts.PatchesFiles)
+	if err != nil {
+		return nil, fmt.Errorf("resolve patches: %w", err)
+	}
+
 	log.Default.Debug(ctx, "Build transformed resource specs")
 
 	transformedResSpecs, err := spec.BuildTransformedResourceSpecs(ctx, opts.ReleaseNamespace, renderChartResult.ResourceSpecs, []spec.ResourceTransformer{
@@ -294,9 +309,16 @@ func ChartRender(ctx context.Context, opts ChartRenderOptions) (*ChartRenderResu
 		return nil, fmt.Errorf("build transformed resource specs: %w", err)
 	}
 
+	log.Default.Debug(ctx, "Build render patched resource specs")
+
+	renderPatchedResSpecs, err := spec.BuildRenderPatchedResourceSpecs(ctx, opts.ReleaseNamespace, transformedResSpecs, patches.Render)
+	if err != nil {
+		return nil, fmt.Errorf("build render patched resource specs: %w", err)
+	}
+
 	log.Default.Debug(ctx, "Build releasable resource specs")
 
-	resSpecs, err := spec.BuildPatchedResourceSpecs(ctx, opts.ReleaseNamespace, transformedResSpecs, []spec.ResourcePatcher{
+	resSpecs, err := spec.BuildPatchedResourceSpecs(ctx, opts.ReleaseNamespace, renderPatchedResSpecs, []spec.ResourcePatcher{
 		spec.NewExtraMetadataPatcher(opts.ExtraAnnotations, opts.ExtraLabels),
 		spec.NewExtraMetadataPatcher(opts.ExtraRuntimeAnnotations, opts.ExtraRuntimeLabels),
 		spec.NewSecretStringDataPatcher(),

--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -180,24 +180,40 @@ func printReport(ctx context.Context, report *ReleaseReportV3) {
 	}
 }
 
-func resolveDiffPatches(chart helmchart.Accessor, defaultDisable bool, patchesFiles []string) ([]spec.DiffPatch, error) {
-	var patches []spec.DiffPatch
+// Chart-shipped rules are scoped to their own chart subtree, rules from patches files are not.
+// Both kinds are compiled right away, so an invalid rule fails before anything is applied.
+func resolvePatches(chart helmchart.Accessor, defaultDisable bool, patchesFiles []string) (spec.CompiledPatches, error) {
+	var patches spec.Patches
 
 	if !defaultDisable {
 		chartPatches, err := spec.CollectChartPatches(chart)
 		if err != nil {
-			return nil, fmt.Errorf("collect chart patches: %w", err)
+			return spec.CompiledPatches{}, fmt.Errorf("collect chart patches: %w", err)
 		}
 
-		patches = append(patches, chartPatches...)
+		patches.Diff = append(patches.Diff, chartPatches.Diff...)
+		patches.Render = append(patches.Render, chartPatches.Render...)
 	}
 
 	filePatches, err := spec.LoadPatchesFiles(patchesFiles)
 	if err != nil {
-		return nil, fmt.Errorf("load patches files: %w", err)
+		return spec.CompiledPatches{}, fmt.Errorf("load patches files: %w", err)
 	}
 
-	return append(patches, filePatches...), nil
+	patches.Diff = append(patches.Diff, filePatches.Diff...)
+	patches.Render = append(patches.Render, filePatches.Render...)
+
+	diffPatches, err := spec.CompilePatches(patches.Diff)
+	if err != nil {
+		return spec.CompiledPatches{}, fmt.Errorf("compile diff patches: %w", err)
+	}
+
+	renderPatches, err := spec.CompilePatches(patches.Render)
+	if err != nil {
+		return spec.CompiledPatches{}, fmt.Errorf("compile render patches: %w", err)
+	}
+
+	return spec.CompiledPatches{Diff: diffPatches, Render: renderPatches}, nil
 }
 
 func runFailurePlan(ctx context.Context, releaseNamespace string, failedPlan *plan.Plan, installableInfos []*plan.InstallableResourceInfo, releaseInfos []*plan.ReleaseInfo, taskStore *kdutil.Concurrent[*statestore.TaskStore], logStore *kdutil.Concurrent[*logstore.LogStore], informerFactory *kdutil.Concurrent[*informer.InformerFactory], history *release.History, clientFactory *kube.ClientFactory, opts runFailureInstallPlanOptions) (result *runFailurePlanResult, nonCritErrs, critErrs *util.MultiError) {

--- a/pkg/action/release_install.go
+++ b/pkg/action/release_install.go
@@ -386,6 +386,13 @@ func releaseInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc, re
 			return fmt.Errorf("render chart: %w", err)
 		}
 
+		log.Default.Debug(ctx, "Resolve patches")
+
+		patches, err := resolvePatches(renderChartResult.Chart, opts.DefaultPatchesDisable, opts.PatchesFiles)
+		if err != nil {
+			return fmt.Errorf("resolve patches: %w", err)
+		}
+
 		log.Default.Debug(ctx, "Build transformed resource specs")
 
 		transformedResSpecs, err := spec.BuildTransformedResourceSpecs(ctx, releaseNamespace, renderChartResult.ResourceSpecs, []spec.ResourceTransformer{
@@ -393,6 +400,13 @@ func releaseInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc, re
 		})
 		if err != nil {
 			return fmt.Errorf("build transformed resource specs: %w", err)
+		}
+
+		log.Default.Debug(ctx, "Build render patched resource specs")
+
+		renderPatchedResSpecs, err := spec.BuildRenderPatchedResourceSpecs(ctx, releaseNamespace, transformedResSpecs, patches.Render)
+		if err != nil {
+			return fmt.Errorf("build render patched resource specs: %w", err)
 		}
 
 		log.Default.Debug(ctx, "Build releasable resource specs")
@@ -406,7 +420,7 @@ func releaseInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc, re
 			patchers = append(patchers, spec.NewLegacyOnlyTrackJobsPatcher())
 		}
 
-		releasableResSpecs, err := spec.BuildPatchedResourceSpecs(ctx, releaseNamespace, transformedResSpecs, patchers)
+		releasableResSpecs, err := spec.BuildPatchedResourceSpecs(ctx, releaseNamespace, renderPatchedResSpecs, patchers)
 		if err != nil {
 			return fmt.Errorf("build releasable resource specs: %w", err)
 		}
@@ -470,13 +484,8 @@ func releaseInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc, re
 			}
 		}
 
-		diffPatches, err := resolveDiffPatches(renderChartResult.Chart, opts.DefaultPatchesDisable, opts.PatchesFiles)
-		if err != nil {
-			return fmt.Errorf("resolve diff patches: %w", err)
-		}
-
 		instResInfos, delResInfos, err = plan.BuildResourceInfos(ctx, deployType, releaseName, releaseNamespace, instResources, delResources, prevReleaseFailed, clientFactory, plan.BuildResourceInfosOptions{
-			DiffPatches:                        diffPatches,
+			DiffPatches:                        patches.Diff,
 			NetworkParallelism:                 opts.NetworkParallelism,
 			NoRemoveManualChanges:              opts.NoRemoveManualChanges,
 			LastDeployedOrLastRelResourceSpecs: lastDeployedOrLastRelResSpecs,
@@ -922,13 +931,13 @@ func runRollbackPlan(ctx context.Context, releaseName, releaseNamespace string, 
 		return nil, nonCritErrs, critErrs.Add(fmt.Errorf("convert last deployed or last release to resource specs: %w", err))
 	}
 
-	diffPatches, err := resolveDiffPatches(chartAccessor, opts.DefaultPatchesDisable, opts.PatchesFiles)
+	patches, err := resolvePatches(chartAccessor, opts.DefaultPatchesDisable, opts.PatchesFiles)
 	if err != nil {
-		return nil, nonCritErrs, critErrs.Add(fmt.Errorf("resolve diff patches: %w", err))
+		return nil, nonCritErrs, critErrs.Add(fmt.Errorf("resolve patches: %w", err))
 	}
 
 	instResInfos, delResInfos, err := plan.BuildResourceInfos(ctx, common.DeployTypeRollback, releaseName, releaseNamespace, instResources, delResources, true, clientFactory, plan.BuildResourceInfosOptions{
-		DiffPatches:                        diffPatches,
+		DiffPatches:                        patches.Diff,
 		NetworkParallelism:                 opts.NetworkParallelism,
 		NoRemoveManualChanges:              opts.NoRemoveManualChanges,
 		LastDeployedOrLastRelResourceSpecs: lastDeployedOrLastRelResSpecs,

--- a/pkg/action/release_plan_install.go
+++ b/pkg/action/release_plan_install.go
@@ -280,6 +280,13 @@ func releasePlanInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc
 		return nil, fmt.Errorf("render chart: %w", err)
 	}
 
+	log.Default.Debug(ctx, "Resolve patches")
+
+	patches, err := resolvePatches(renderChartResult.Chart, opts.DefaultPatchesDisable, opts.PatchesFiles)
+	if err != nil {
+		return nil, fmt.Errorf("resolve patches: %w", err)
+	}
+
 	log.Default.Debug(ctx, "Build transformed resource specs")
 
 	transformedResSpecs, err := spec.BuildTransformedResourceSpecs(ctx, releaseNamespace, renderChartResult.ResourceSpecs, []spec.ResourceTransformer{
@@ -287,6 +294,13 @@ func releasePlanInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build transformed resource specs: %w", err)
+	}
+
+	log.Default.Debug(ctx, "Build render patched resource specs")
+
+	renderPatchedResSpecs, err := spec.BuildRenderPatchedResourceSpecs(ctx, releaseNamespace, transformedResSpecs, patches.Render)
+	if err != nil {
+		return nil, fmt.Errorf("build render patched resource specs: %w", err)
 	}
 
 	log.Default.Debug(ctx, "Build releasable resource specs")
@@ -300,7 +314,7 @@ func releasePlanInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc
 		patchers = append(patchers, spec.NewLegacyOnlyTrackJobsPatcher())
 	}
 
-	releasableResSpecs, err := spec.BuildPatchedResourceSpecs(ctx, releaseNamespace, transformedResSpecs, patchers)
+	releasableResSpecs, err := spec.BuildPatchedResourceSpecs(ctx, releaseNamespace, renderPatchedResSpecs, patchers)
 	if err != nil {
 		return nil, fmt.Errorf("build releasable resource specs: %w", err)
 	}
@@ -361,13 +375,8 @@ func releasePlanInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc
 		}
 	}
 
-	diffPatches, err := resolveDiffPatches(renderChartResult.Chart, opts.DefaultPatchesDisable, opts.PatchesFiles)
-	if err != nil {
-		return nil, fmt.Errorf("resolve diff patches: %w", err)
-	}
-
 	instResInfos, delResInfos, err := plan.BuildResourceInfos(ctx, deployType, releaseName, releaseNamespace, instResources, delResources, prevReleaseFailed, clientFactory, plan.BuildResourceInfosOptions{
-		DiffPatches:                        diffPatches,
+		DiffPatches:                        patches.Diff,
 		NetworkParallelism:                 opts.NetworkParallelism,
 		NoRemoveManualChanges:              opts.NoRemoveManualChanges,
 		LastDeployedOrLastRelResourceSpecs: lastDeployedOrLastRelResSpecs,

--- a/pkg/action/release_rollback.go
+++ b/pkg/action/release_rollback.go
@@ -61,8 +61,9 @@ type ReleaseRollbackOptions struct {
 	// NoShowNotes, when true, suppresses printing of NOTES.txt after successful rollback.
 	// NOTES.txt typically contains usage instructions and next steps.
 	NoShowNotes bool
-	// PatchesFiles are paths to additional patches files (diff patches for drift
-	// detection) applied on top of chart-shipped ones during the rollback plan.
+	// PatchesFiles are paths to additional patches files applied on top of
+	// chart-shipped ones during the rollback plan. Nothing is rendered during a
+	// rollback, so only diff patches (drift detection) have an effect here.
 	PatchesFiles []string
 	// ReleaseHistoryLimit sets the maximum number of release revisions to keep in storage.
 	// When exceeded, the oldest revisions are deleted. Defaults to DefaultReleaseHistoryLimit if not set or <= 0.
@@ -319,13 +320,13 @@ func releaseRollback(ctx context.Context, ctxCancelFn context.CancelCauseFunc, r
 		}
 	}
 
-	diffPatches, err := resolveDiffPatches(chartAccessor, opts.DefaultPatchesDisable, opts.PatchesFiles)
+	patches, err := resolvePatches(chartAccessor, opts.DefaultPatchesDisable, opts.PatchesFiles)
 	if err != nil {
-		return fmt.Errorf("resolve diff patches: %w", err)
+		return fmt.Errorf("resolve patches: %w", err)
 	}
 
 	instResInfos, delResInfos, err := plan.BuildResourceInfos(ctx, deployType, releaseName, releaseNamespace, instResources, delResources, prevReleaseFailed, clientFactory, plan.BuildResourceInfosOptions{
-		DiffPatches:                        diffPatches,
+		DiffPatches:                        patches.Diff,
 		NetworkParallelism:                 opts.NetworkParallelism,
 		NoRemoveManualChanges:              opts.NoRemoveManualChanges,
 		LastDeployedOrLastRelResourceSpecs: lastDeployedOrLastRelResSpecs,

--- a/pkg/action/release_uninstall.go
+++ b/pkg/action/release_uninstall.go
@@ -59,8 +59,9 @@ type ReleaseUninstallOptions struct {
 	// NoRemoveManualChanges, when true, preserves fields manually added to resources in the cluster
 	// that are not present in the chart manifests. By default, such fields are removed during deletion.
 	NoRemoveManualChanges bool
-	// PatchesFiles are paths to additional patches files (diff patches for drift
-	// detection) applied on top of chart-shipped ones during the uninstall plan.
+	// PatchesFiles are paths to additional patches files applied on top of
+	// chart-shipped ones during the uninstall plan. Nothing is rendered during an
+	// uninstall, so only diff patches (drift detection) have an effect here.
 	PatchesFiles []string
 	// ReleaseHistoryLimit sets the maximum number of release revisions to keep in storage.
 	// Defaults to DefaultReleaseHistoryLimit if not set or <= 0.
@@ -245,13 +246,13 @@ func releaseUninstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc, 
 			return fmt.Errorf("access chart of previous release: %w", err)
 		}
 
-		diffPatches, err := resolveDiffPatches(uninstallChart, opts.DefaultPatchesDisable, opts.PatchesFiles)
+		patches, err := resolvePatches(uninstallChart, opts.DefaultPatchesDisable, opts.PatchesFiles)
 		if err != nil {
-			return fmt.Errorf("resolve diff patches: %w", err)
+			return fmt.Errorf("resolve patches: %w", err)
 		}
 
 		instResInfos, delResInfos, err := plan.BuildResourceInfos(ctx, deployType, releaseName, releaseNamespace, instResources, delResources, prevReleaseFailed, clientFactory, plan.BuildResourceInfosOptions{
-			DiffPatches:                        diffPatches,
+			DiffPatches:                        patches.Diff,
 			NetworkParallelism:                 opts.NetworkParallelism,
 			NoRemoveManualChanges:              opts.NoRemoveManualChanges,
 			LastDeployedOrLastRelResourceSpecs: prevRelResSpecs,

--- a/pkg/common/options.go
+++ b/pkg/common/options.go
@@ -240,11 +240,12 @@ type ReleaseInstallRuntimeOptions struct {
 	// DefaultDeletePropagation sets the deletion propagation policy for resource deletions.
 	DefaultDeletePropagation string `json:"defaultDeletePropagation"`
 	// PatchesFiles are paths to patches files (same format as a chart-shipped
-	// patches.yaml) whose diff patch rules are applied on top of chart-shipped
-	// ones. Diff patches affect ONLY drift detection: each matching rule's jq
-	// transform is applied identically to the live and the dry-apply object before
-	// comparison, so normalized-away fields never produce a diff. They never change
-	// what is rendered or applied. These rules are UNSCOPED (they may match any
+	// patches.yaml) whose rules are applied on top of chart-shipped ones. Render
+	// patches are applied to the rendered resources, so they change what is released
+	// and applied. Diff patches affect ONLY
+	// drift detection: each matching rule's jq transform is applied identically to
+	// the live and the dry-apply object before comparison, so normalized-away fields
+	// never produce a diff. Rules from these files are UNSCOPED (they may match any
 	// resource), unlike chart-shipped rules which are scoped to their chart subtree.
 	PatchesFiles []string `json:"patchesFiles"`
 	// DefaultPatchesDisable, when true, ignores chart-shipped patches.yaml files

--- a/pkg/common/options.go
+++ b/pkg/common/options.go
@@ -241,12 +241,12 @@ type ReleaseInstallRuntimeOptions struct {
 	DefaultDeletePropagation string `json:"defaultDeletePropagation"`
 	// PatchesFiles are paths to patches files (same format as a chart-shipped
 	// patches.yaml) whose rules are applied on top of chart-shipped ones. Render
-	// patches are applied to the rendered resources, so they change what is released
-	// and applied. Diff patches affect ONLY
-	// drift detection: each matching rule's jq transform is applied identically to
-	// the live and the dry-apply object before comparison, so normalized-away fields
-	// never produce a diff. Rules from these files are UNSCOPED (they may match any
-	// resource), unlike chart-shipped rules which are scoped to their chart subtree.
+	// patches are applied to the rendered resources, so they change what is
+	// released and applied. Diff patches affect ONLY drift detection: each
+	// matching rule's jq transform is applied identically to the live and the
+	// dry-apply object before comparison, so normalized-away fields never produce
+	// a diff. Rules from these files are UNSCOPED (they may match any resource),
+	// unlike chart-shipped rules which are scoped to their chart subtree.
 	PatchesFiles []string `json:"patchesFiles"`
 	// DefaultPatchesDisable, when true, ignores chart-shipped patches.yaml files
 	// (from the top-level chart and subcharts).

--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -876,11 +876,11 @@ func resourceInstallType(ctx context.Context, localRes *resource.InstallableReso
 		// namespace selector dimension.
 		namespace := getObj.GetNamespace()
 
-		if patchedGetObj, err = spec.ApplyPatches(diffPatches, localRes.ResourceMeta, namespace, getObj); err != nil {
+		if patchedGetObj, err = spec.ApplyPatches(ctx, diffPatches, localRes.ResourceMeta, namespace, getObj); err != nil {
 			return "", false, fmt.Errorf("apply diff patches to live version of resource %q: %w", localRes.IDHuman(), err)
 		}
 
-		if patchedDryApplyObj, err = spec.ApplyPatches(diffPatches, localRes.ResourceMeta, namespace, dryApplyObj); err != nil {
+		if patchedDryApplyObj, err = spec.ApplyPatches(ctx, diffPatches, localRes.ResourceMeta, namespace, dryApplyObj); err != nil {
 			return "", false, fmt.Errorf("apply diff patches to dry-apply version of resource %q: %w", localRes.IDHuman(), err)
 		}
 	}

--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -78,7 +78,7 @@ type DeletableResourceInfo struct {
 }
 
 type BuildResourceInfosOptions struct {
-	DiffPatches                        []spec.DiffPatch
+	DiffPatches                        []*spec.CompiledPatch
 	ExtraRuntimeAnnotations            map[string]string
 	ExtraRuntimeLabels                 map[string]string
 	LastDeployedOrLastRelResourceSpecs []*spec.ResourceSpec
@@ -91,11 +91,6 @@ type BuildResourceInfosOptions struct {
 // more info, and here we actually decide what to do with each resource. Initially all this logic
 // was in BuildPlan, but it became way too complex, so we extracted it here.
 func BuildResourceInfos(ctx context.Context, deployType common.DeployType, releaseName, releaseNamespace string, instResources []*resource.InstallableResource, delResources []*resource.DeletableResource, prevReleaseFailed bool, clientFactory kube.ClientFactorier, opts BuildResourceInfosOptions) (instResourceInfos []*InstallableResourceInfo, delResourceInfos []*DeletableResourceInfo, err error) {
-	diffPatches, err := spec.CompileDiffPatches(opts.DiffPatches)
-	if err != nil {
-		return nil, nil, fmt.Errorf("compile diff patches: %w", err)
-	}
-
 	totalResourcesCount := len(instResources) + len(delResources)
 
 	routines := lo.Max([]int{len(instResources) / lo.Max([]int{totalResourcesCount, 1}) * opts.NetworkParallelism, 1})
@@ -103,7 +98,7 @@ func BuildResourceInfos(ctx context.Context, deployType common.DeployType, relea
 	instResourcesPool := pool.NewWithResults[[]*InstallableResourceInfo]().WithContext(ctx).WithMaxGoroutines(routines).WithCancelOnError().WithFirstError()
 	for _, res := range instResources {
 		instResourcesPool.Go(func(ctx context.Context) ([]*InstallableResourceInfo, error) {
-			infos, err := buildInstallableResourceInfo(ctx, res, deployType, releaseNamespace, prevReleaseFailed, opts.NoRemoveManualChanges, clientFactory, opts, diffPatches)
+			infos, err := buildInstallableResourceInfo(ctx, res, deployType, releaseNamespace, prevReleaseFailed, opts.NoRemoveManualChanges, clientFactory, opts, opts.DiffPatches)
 			if err != nil {
 				return nil, fmt.Errorf("build installable resource info: %w", err)
 			}
@@ -165,7 +160,7 @@ func ResourceInstallTypeSortHandler(type1, type2 ResourceInstallType) bool {
 	return type1I < type2I
 }
 
-func buildInstallableResourceInfo(ctx context.Context, localRes *resource.InstallableResource, deployType common.DeployType, releaseNamespace string, prevRelFailed, noRemoveManualChanges bool, clientFactory kube.ClientFactorier, opts BuildResourceInfosOptions, diffPatches []*spec.CompiledDiffPatch) ([]*InstallableResourceInfo, error) {
+func buildInstallableResourceInfo(ctx context.Context, localRes *resource.InstallableResource, deployType common.DeployType, releaseNamespace string, prevRelFailed, noRemoveManualChanges bool, clientFactory kube.ClientFactorier, opts BuildResourceInfosOptions, diffPatches []*spec.CompiledPatch) ([]*InstallableResourceInfo, error) {
 	var stages []common.Stage
 	switch deployType {
 	case common.DeployTypeInitial, common.DeployTypeInstall:
@@ -836,7 +831,7 @@ func removeUndesirableManagers(managedFields []v1.ManagedFieldsEntry, oursEntry 
 	return newManagedFields, newOursEntry, changed
 }
 
-func resourceInstallType(ctx context.Context, localRes *resource.InstallableResource, getObj, dryApplyObj *unstructured.Unstructured, dryApplyErr error, extraRuntimeAnnotations, extraRuntimeLabels map[string]string, resourcePolicies []common.ResourcePolicy, diffPatches []*spec.CompiledDiffPatch) (installType ResourceInstallType, skippedByPolicy bool, err error) {
+func resourceInstallType(ctx context.Context, localRes *resource.InstallableResource, getObj, dryApplyObj *unstructured.Unstructured, dryApplyErr error, extraRuntimeAnnotations, extraRuntimeLabels map[string]string, resourcePolicies []common.ResourcePolicy, diffPatches []*spec.CompiledPatch) (installType ResourceInstallType, skippedByPolicy bool, err error) {
 	skipCreate := lo.Contains(resourcePolicies, common.ResourcePolicySkipCreate)
 	skipUpdate := lo.Contains(resourcePolicies, common.ResourcePolicySkipUpdate)
 	skipRecreate := lo.Contains(resourcePolicies, common.ResourcePolicySkipRecreate)
@@ -881,11 +876,11 @@ func resourceInstallType(ctx context.Context, localRes *resource.InstallableReso
 		// namespace selector dimension.
 		namespace := getObj.GetNamespace()
 
-		if patchedGetObj, err = spec.ApplyDiffPatches(diffPatches, localRes.ResourceMeta, namespace, getObj); err != nil {
+		if patchedGetObj, err = spec.ApplyPatches(diffPatches, localRes.ResourceMeta, namespace, getObj); err != nil {
 			return "", false, fmt.Errorf("apply diff patches to live version of resource %q: %w", localRes.IDHuman(), err)
 		}
 
-		if patchedDryApplyObj, err = spec.ApplyDiffPatches(diffPatches, localRes.ResourceMeta, namespace, dryApplyObj); err != nil {
+		if patchedDryApplyObj, err = spec.ApplyPatches(diffPatches, localRes.ResourceMeta, namespace, dryApplyObj); err != nil {
 			return "", false, fmt.Errorf("apply diff patches to dry-apply version of resource %q: %w", localRes.IDHuman(), err)
 		}
 	}

--- a/pkg/plan/resource_info_test.go
+++ b/pkg/plan/resource_info_test.go
@@ -572,27 +572,16 @@ func (s *ResourceInfoSuite) TestBuildResourceInfosDiffPatches() {
 
 		localRes := updatedInstallableResource(&s.Suite, s.releaseName, s.releaseNamespace)
 
+		diffPatches, err := spec.CompilePatches([]spec.Patch{{Patch: `del(.data.key2)`}})
+		s.Require().NoError(err)
+
 		instResInfos, _, err := plan.BuildResourceInfos(context.Background(), common.DeployTypeInitial, s.releaseName, s.releaseNamespace, []*resource.InstallableResource{localRes}, nil, false, s.clientFactory, plan.BuildResourceInfosOptions{
 			NetworkParallelism: 10,
-			DiffPatches: []spec.DiffPatch{
-				{Patch: `del(.data.key2)`},
-			},
+			DiffPatches:        diffPatches,
 		})
 		s.Require().NoError(err)
 		s.Require().Len(instResInfos, 1)
 		s.Require().Equal(plan.ResourceInstallTypeNone, instResInfos[0].MustInstall)
-	})
-
-	s.Run(`invalid diff patch fails closed`, func() {
-		localRes := defaultInstallableResource(s.releaseName, s.releaseNamespace)
-
-		_, _, err := plan.BuildResourceInfos(context.Background(), common.DeployTypeInitial, s.releaseName, s.releaseNamespace, []*resource.InstallableResource{localRes}, nil, false, s.clientFactory, plan.BuildResourceInfosOptions{
-			NetworkParallelism: 10,
-			DiffPatches: []spec.DiffPatch{
-				{Patch: `del(.data.key2`},
-			},
-		})
-		s.Require().Error(err)
 	})
 }
 

--- a/pkg/resource/spec/export_test.go
+++ b/pkg/resource/spec/export_test.go
@@ -1,6 +1,10 @@
 package spec
 
-import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
 var (
 	// CompilePatch and ParsePatchesFile expose unexported symbols to the
@@ -10,6 +14,6 @@ var (
 )
 
 // Transform exposes the unexported transform method to the external spec_test package.
-func (c *CompiledPatch) Transform(unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	return c.transform(unstruct)
+func (c *CompiledPatch) Transform(ctx context.Context, unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	return c.transform(ctx, unstruct)
 }

--- a/pkg/resource/spec/export_test.go
+++ b/pkg/resource/spec/export_test.go
@@ -3,13 +3,13 @@ package spec
 import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 var (
-	// CompileDiffPatch and ParsePatchesFile expose unexported symbols to the
+	// CompilePatch and ParsePatchesFile expose unexported symbols to the
 	// external spec_test package.
-	CompileDiffPatch = compileDiffPatch
+	CompilePatch     = compilePatch
 	ParsePatchesFile = parsePatchesFile
 )
 
 // Transform exposes the unexported transform method to the external spec_test package.
-func (c *CompiledDiffPatch) Transform(unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (c *CompiledPatch) Transform(unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	return c.transform(unstruct)
 }

--- a/pkg/resource/spec/helpers_ai_test.go
+++ b/pkg/resource/spec/helpers_ai_test.go
@@ -1,0 +1,33 @@
+//go:build ai_tests
+
+package spec_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/werf/nelm/pkg/resource/spec"
+)
+
+func renderedSpec(t *testing.T, name, namespace, filePath string, annotations map[string]interface{}) *spec.ResourceSpec {
+	t.Helper()
+
+	metadata := map[string]interface{}{"name": name}
+	if namespace != "" {
+		metadata["namespace"] = namespace
+	}
+
+	if annotations != nil {
+		metadata["annotations"] = annotations
+	}
+
+	unstruct := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   metadata,
+		"spec":       map[string]interface{}{"replicas": int64(3)},
+	}}
+
+	return spec.NewResourceSpec(unstruct, "prod", spec.ResourceSpecOptions{FilePath: filePath})
+}

--- a/pkg/resource/spec/patches.go
+++ b/pkg/resource/spec/patches.go
@@ -353,7 +353,7 @@ func normalizeNumbers(value interface{}) (interface{}, error) {
 			return f, nil
 		}
 
-		return v.String(), nil
+		return nil, fmt.Errorf("number %s cannot be represented as int64 or float64", v.String())
 	default:
 		return value, nil
 	}

--- a/pkg/resource/spec/patches.go
+++ b/pkg/resource/spec/patches.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -90,7 +91,7 @@ func (c *CompiledPatch) Match(resMeta *ResourceMeta, namespace string) bool {
 // transform runs the compiled jq program over a deep copy of the object and
 // returns the single object output. Zero, multiple, or non-object output is an
 // error, and a jq panic is recovered into an error; the input is never mutated.
-func (c *CompiledPatch) transform(unstruct *unstructured.Unstructured) (result *unstructured.Unstructured, err error) {
+func (c *CompiledPatch) transform(ctx context.Context, unstruct *unstructured.Unstructured) (result *unstructured.Unstructured, err error) {
 	// Unstructured stores integers as int64, which gojq rejects; round-trip
 	// through JSON with UseNumber so numbers reach gojq as json.Number.
 	input, err := toJQInput(unstruct.Object)
@@ -105,7 +106,7 @@ func (c *CompiledPatch) transform(unstruct *unstructured.Unstructured) (result *
 		}
 	}()
 
-	iter := c.code.Run(input)
+	iter := c.code.RunWithContext(ctx, input)
 
 	first, ok := iter.Next()
 	if !ok {
@@ -135,7 +136,7 @@ func (c *CompiledPatch) transform(unstruct *unstructured.Unstructured) (result *
 // ApplyPatches runs every rule whose matcher matches the resource, threading each
 // transform's output into the next, and returns a transformed deep copy; the
 // input is never mutated. namespace is the resource's true namespace.
-func ApplyPatches(patches []*CompiledPatch, resMeta *ResourceMeta, namespace string, unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func ApplyPatches(ctx context.Context, patches []*CompiledPatch, resMeta *ResourceMeta, namespace string, unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	result := unstruct
 	transformed := false
 
@@ -144,7 +145,7 @@ func ApplyPatches(patches []*CompiledPatch, resMeta *ResourceMeta, namespace str
 			continue
 		}
 
-		out, err := patch.transform(result)
+		out, err := patch.transform(ctx, result)
 		if err != nil {
 			return nil, fmt.Errorf("apply patch #%d: %w", i+1, err)
 		}

--- a/pkg/resource/spec/patches.go
+++ b/pkg/resource/spec/patches.go
@@ -272,7 +272,12 @@ func fromJQOutput(value interface{}) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 
-	normalized, ok := normalizeNumbers(decoded).(map[string]interface{})
+	result, err := normalizeNumbers(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("normalize jq output numbers: %w", err)
+	}
+
+	normalized, ok := result.(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("jq program output is not an object")
 	}
@@ -311,32 +316,46 @@ func compilePatch(patch Patch) (*CompiledPatch, error) {
 	return &CompiledPatch{chartScope: patch.ChartScope, code: code, matcher: patch.Match}, nil
 }
 
-func normalizeNumbers(value interface{}) interface{} {
+func normalizeNumbers(value interface{}) (interface{}, error) {
 	switch v := value.(type) {
 	case map[string]interface{}:
 		for key, elem := range v {
-			v[key] = normalizeNumbers(elem)
+			normalized, err := normalizeNumbers(elem)
+			if err != nil {
+				return nil, err
+			}
+
+			v[key] = normalized
 		}
 
-		return v
+		return v, nil
 	case []interface{}:
 		for i, elem := range v {
-			v[i] = normalizeNumbers(elem)
+			normalized, err := normalizeNumbers(elem)
+			if err != nil {
+				return nil, err
+			}
+
+			v[i] = normalized
 		}
 
-		return v
+		return v, nil
 	case json.Number:
 		if i, err := v.Int64(); err == nil {
-			return i
+			return i, nil
+		}
+
+		if s := v.String(); !strings.ContainsAny(s, ".eE") {
+			return nil, fmt.Errorf("integer %s overflows int64 and cannot be represented exactly", s)
 		}
 
 		if f, err := v.Float64(); err == nil {
-			return f
+			return f, nil
 		}
 
-		return v.String()
+		return v.String(), nil
 	default:
-		return value
+		return value, nil
 	}
 }
 

--- a/pkg/resource/spec/patches.go
+++ b/pkg/resource/spec/patches.go
@@ -15,30 +15,46 @@ import (
 )
 
 const (
-	DiffPatchTypeJQ DiffPatchType = "jq"
+	PatchTypeJQ PatchType = "jq"
 
 	// patchesFileName is the conventional name of a chart-shipped patches file.
 	patchesFileName = "patches.yaml"
 )
 
-// DiffPatchType is the transform kind of a diff patch.
-type DiffPatchType string
+// PatchType is the transform kind of patch.
+type PatchType string
 
-// PatchesFile is the on-disk format of a patches file. Only diffPatches is
-// supported today; the top-level key leaves room for future siblings.
+// PatchesFile is the on-disk format of a patches file.
 type PatchesFile struct {
-	DiffPatches []DiffPatch `json:"diffPatches,omitempty"`
+	DiffPatches   []Patch `json:"diffPatches,omitempty"`
+	RenderPatches []Patch `json:"renderPatches,omitempty"`
 }
 
-// DiffPatch is a diff-time normalization rule. It affects ONLY drift detection:
-// the transform is applied identically to the live and the dry-apply object
-// before they are compared, so normalized-away fields never produce a diff.
-type DiffPatch struct {
+// Patches are patch rules grouped by the point at which they are applied.
+type Patches struct {
+	// Diff rules affect ONLY drift detection: the transform is applied identically
+	// to the live and the dry-apply object before they are compared, so
+	// normalized-away fields never produce a diff. They never change what is
+	// rendered or applied.
+	Diff []Patch
+	// Render rules are applied to the rendered resources, so they do change what is
+	// released and applied to the cluster.
+	Render []Patch
+}
+
+// CompiledPatches are Patches with their jq programs compiled.
+type CompiledPatches struct {
+	Diff   []*CompiledPatch
+	Render []*CompiledPatch
+}
+
+// Patch is a jq transform applied to every resource its matcher matches.
+type Patch struct {
 	// Match chooses which resources this rule applies to. An empty matcher
 	// matches every resource.
 	Match ResourceMatcher `json:"match,omitempty"`
 	// Type is the transform kind. Only "jq" is supported; empty defaults to "jq".
-	Type DiffPatchType `json:"type,omitempty"`
+	Type PatchType `json:"type,omitempty"`
 	// Patch is the jq program: it receives the whole raw resource object and must
 	// return exactly one object.
 	Patch string `json:"patch,omitempty"`
@@ -48,9 +64,9 @@ type DiffPatch struct {
 	ChartScope string `json:"-"`
 }
 
-// CompiledDiffPatch is a DiffPatch with its jq program compiled once, ready to
-// match and transform many resources.
-type CompiledDiffPatch struct {
+// CompiledPatch is a Patch with its jq program compiled once, ready to match and
+// transform many resources.
+type CompiledPatch struct {
 	chartScope string
 	code       *gojq.Code
 	matcher    ResourceMatcher
@@ -59,7 +75,7 @@ type CompiledDiffPatch struct {
 // Match reports whether the rule matches the resource. namespace is the
 // resource's true namespace (empty only for cluster-scoped resources), passed in
 // because ResourceMeta.Namespace is blanked for release-namespace resources.
-func (c *CompiledDiffPatch) Match(resMeta *ResourceMeta, namespace string) bool {
+func (c *CompiledPatch) Match(resMeta *ResourceMeta, namespace string) bool {
 	if !resourceInChartScope(c.chartScope, resMeta.FilePath) {
 		return false
 	}
@@ -74,7 +90,7 @@ func (c *CompiledDiffPatch) Match(resMeta *ResourceMeta, namespace string) bool 
 // transform runs the compiled jq program over a deep copy of the object and
 // returns the single object output. Zero, multiple, or non-object output is an
 // error, and a jq panic is recovered into an error; the input is never mutated.
-func (c *CompiledDiffPatch) transform(unstruct *unstructured.Unstructured) (result *unstructured.Unstructured, err error) {
+func (c *CompiledPatch) transform(unstruct *unstructured.Unstructured) (result *unstructured.Unstructured, err error) {
 	// Unstructured stores integers as int64, which gojq rejects; round-trip
 	// through JSON with UseNumber so numbers reach gojq as json.Number.
 	input, err := toJQInput(unstruct.Object)
@@ -116,10 +132,10 @@ func (c *CompiledDiffPatch) transform(unstruct *unstructured.Unstructured) (resu
 	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-// ApplyDiffPatches runs every rule whose matcher matches the resource, threading
-// each transform's output into the next, and returns a transformed deep copy; the
+// ApplyPatches runs every rule whose matcher matches the resource, threading each
+// transform's output into the next, and returns a transformed deep copy; the
 // input is never mutated. namespace is the resource's true namespace.
-func ApplyDiffPatches(patches []*CompiledDiffPatch, resMeta *ResourceMeta, namespace string, unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func ApplyPatches(patches []*CompiledPatch, resMeta *ResourceMeta, namespace string, unstruct *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	result := unstruct
 	transformed := false
 
@@ -130,7 +146,7 @@ func ApplyDiffPatches(patches []*CompiledDiffPatch, resMeta *ResourceMeta, names
 
 		out, err := patch.transform(result)
 		if err != nil {
-			return nil, fmt.Errorf("apply diff patch #%d: %w", i+1, err)
+			return nil, fmt.Errorf("apply patch #%d: %w", i+1, err)
 		}
 
 		result = out
@@ -146,30 +162,31 @@ func ApplyDiffPatches(patches []*CompiledDiffPatch, resMeta *ResourceMeta, names
 
 // CollectChartPatches returns every chart-shipped patches.yaml rule in the chart
 // tree, ordered leaf-first and each constrained to its own chart subtree.
-func CollectChartPatches(chart helmchart.Accessor) ([]DiffPatch, error) {
+func CollectChartPatches(chart helmchart.Accessor) (Patches, error) {
 	if chart == nil {
-		return nil, nil
+		return Patches{}, nil
 	}
 
 	chartPath := chart.ChartFullPath()
 
-	var patches []DiffPatch
+	var patches Patches
 
 	for _, dep := range chart.Dependencies() {
 		depAccessor, err := helmchart.NewAccessor(dep)
 		if err != nil {
-			return nil, fmt.Errorf("access subchart of %q: %w", chartPath, err)
+			return Patches{}, fmt.Errorf("access subchart of %q: %w", chartPath, err)
 		}
 
 		depPatches, err := CollectChartPatches(depAccessor)
 		if err != nil {
-			return nil, err
+			return Patches{}, err
 		}
 
-		patches = append(patches, depPatches...)
+		patches.Diff = append(patches.Diff, depPatches.Diff...)
+		patches.Render = append(patches.Render, depPatches.Render...)
 	}
 
-	var own []DiffPatch
+	var own Patches
 	for _, f := range chart.Files() {
 		if f.Name != patchesFileName {
 			continue
@@ -177,7 +194,7 @@ func CollectChartPatches(chart helmchart.Accessor) ([]DiffPatch, error) {
 
 		ownPatches, err := parsePatchesFile(f.Data)
 		if err != nil {
-			return nil, fmt.Errorf("read %s of chart %q: %w", patchesFileName, chartPath, err)
+			return Patches{}, fmt.Errorf("read %s of chart %q: %w", patchesFileName, chartPath, err)
 		}
 
 		own = ownPatches
@@ -185,26 +202,32 @@ func CollectChartPatches(chart helmchart.Accessor) ([]DiffPatch, error) {
 		break
 	}
 
-	for i := range own {
-		own[i].ChartScope = chartPath
+	for i := range own.Diff {
+		own.Diff[i].ChartScope = chartPath
 	}
 
-	return append(patches, own...), nil
+	for i := range own.Render {
+		own.Render[i].ChartScope = chartPath
+	}
+
+	patches.Diff = append(patches.Diff, own.Diff...)
+	patches.Render = append(patches.Render, own.Render...)
+
+	return patches, nil
 }
 
-// CompileDiffPatches compiles diff patch rules, returning a plan error on the
-// first invalid regexp, unsupported type, empty patch body, or invalid jq
-// program.
-func CompileDiffPatches(patches []DiffPatch) ([]*CompiledDiffPatch, error) {
+// CompilePatches compiles patch rules, returning an error on the first invalid
+// regexp, unsupported type, empty patch body, or invalid jq program.
+func CompilePatches(patches []Patch) ([]*CompiledPatch, error) {
 	if len(patches) == 0 {
 		return nil, nil
 	}
 
-	compiled := make([]*CompiledDiffPatch, 0, len(patches))
+	compiled := make([]*CompiledPatch, 0, len(patches))
 	for i, patch := range patches {
-		c, err := compileDiffPatch(patch)
+		c, err := compilePatch(patch)
 		if err != nil {
-			return nil, fmt.Errorf("compile diff patch #%d: %w", i+1, err)
+			return nil, fmt.Errorf("compile patch #%d: %w", i+1, err)
 		}
 
 		compiled = append(compiled, c)
@@ -215,20 +238,21 @@ func CompileDiffPatches(patches []DiffPatch) ([]*CompiledDiffPatch, error) {
 
 // LoadPatchesFiles reads and parses the given patches file paths, returning their
 // rules concatenated in order.
-func LoadPatchesFiles(paths []string) ([]DiffPatch, error) {
-	var patches []DiffPatch
+func LoadPatchesFiles(paths []string) (Patches, error) {
+	var patches Patches
 	for _, path := range paths {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("read patches file %q: %w", path, err)
+			return Patches{}, fmt.Errorf("read patches file %q: %w", path, err)
 		}
 
 		filePatches, err := parsePatchesFile(data)
 		if err != nil {
-			return nil, fmt.Errorf("patches file %q: %w", path, err)
+			return Patches{}, fmt.Errorf("patches file %q: %w", path, err)
 		}
 
-		patches = append(patches, filePatches...)
+		patches.Diff = append(patches.Diff, filePatches.Diff...)
+		patches.Render = append(patches.Render, filePatches.Render...)
 	}
 
 	return patches, nil
@@ -256,18 +280,18 @@ func fromJQOutput(value interface{}) (map[string]interface{}, error) {
 	return normalized, nil
 }
 
-func compileDiffPatch(patch DiffPatch) (*CompiledDiffPatch, error) {
+func compilePatch(patch Patch) (*CompiledPatch, error) {
 	patchType := patch.Type
 	if patchType == "" {
-		patchType = DiffPatchTypeJQ
+		patchType = PatchTypeJQ
 	}
 
-	if patchType != DiffPatchTypeJQ {
-		return nil, fmt.Errorf("unsupported diff patch type %q, only %q is supported", patch.Type, DiffPatchTypeJQ)
+	if patchType != PatchTypeJQ {
+		return nil, fmt.Errorf("unsupported patch type %q, only %q is supported", patch.Type, PatchTypeJQ)
 	}
 
 	if strings.TrimSpace(patch.Patch) == "" {
-		return nil, fmt.Errorf("diff patch program is empty")
+		return nil, fmt.Errorf("patch program is empty")
 	}
 
 	if err := patch.Match.Validate(); err != nil {
@@ -284,7 +308,7 @@ func compileDiffPatch(patch DiffPatch) (*CompiledDiffPatch, error) {
 		return nil, fmt.Errorf("compile jq program: %w", err)
 	}
 
-	return &CompiledDiffPatch{chartScope: patch.ChartScope, code: code, matcher: patch.Match}, nil
+	return &CompiledPatch{chartScope: patch.ChartScope, code: code, matcher: patch.Match}, nil
 }
 
 func normalizeNumbers(value interface{}) interface{} {
@@ -316,15 +340,15 @@ func normalizeNumbers(value interface{}) interface{} {
 	}
 }
 
-// parsePatchesFile parses a patches file into its diff patch rules. Unknown
-// top-level keys are rejected so typos and unsupported kinds fail loudly.
-func parsePatchesFile(data []byte) ([]DiffPatch, error) {
+// parsePatchesFile parses a patches file into its patch rules. Unknown top-level
+// keys are rejected so typos and unsupported kinds fail loudly.
+func parsePatchesFile(data []byte) (Patches, error) {
 	var file PatchesFile
 	if err := yaml.UnmarshalStrict(data, &file); err != nil {
-		return nil, fmt.Errorf("parse patches file: %w", err)
+		return Patches{}, fmt.Errorf("parse patches file: %w", err)
 	}
 
-	return file.DiffPatches, nil
+	return Patches{Diff: file.DiffPatches, Render: file.RenderPatches}, nil
 }
 
 func resourceInChartScope(chartPath, filePath string) bool {

--- a/pkg/resource/spec/patches_ai_test.go
+++ b/pkg/resource/spec/patches_ai_test.go
@@ -4,6 +4,7 @@ package spec_test
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,17 @@ func TestAI_BuildRenderPatchedResourceSpecs_ContractViolations(t *testing.T) {
 			require.ErrorContains(t, err, "apply render patches to resource")
 		})
 	}
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_IntegerOverflowErrorContext(t *testing.T) {
+	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+	patches, err := spec.CompilePatches([]spec.Patch{{Patch: `.spec.replicas = 9223372036854775807 + 10`}})
+	require.NoError(t, err)
+
+	_, err = spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+	require.ErrorContains(t, err, "apply render patches to resource")
+	require.ErrorContains(t, err, "overflows int64")
 }
 
 func TestAI_BuildRenderPatchedResourceSpecs_NamespaceSelector(t *testing.T) {
@@ -257,6 +269,37 @@ func TestAI_BuildRenderPatchedResourceSpecs_RejectsNonStringMetadata(t *testing.
 			require.ErrorContains(t, err, "expected string")
 		})
 	}
+}
+
+func TestAI_CompiledPatch_Transform_KeepsFractional(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "web"},
+		"spec":       map[string]interface{}{},
+	}}
+
+	c, err := spec.CompilePatch(spec.Patch{Patch: `.spec.ratio = 0.5`})
+	require.NoError(t, err)
+
+	out, err := c.Transform(obj)
+	require.NoError(t, err)
+	require.Equal(t, float64(0.5), out.Object["spec"].(map[string]interface{})["ratio"])
+}
+
+func TestAI_CompiledPatch_Transform_RejectsIntegerOverflow(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "web"},
+		"spec":       map[string]interface{}{"big": int64(math.MaxInt64)},
+	}}
+
+	c, err := spec.CompilePatch(spec.Patch{Patch: `.spec.big += 10`})
+	require.NoError(t, err)
+
+	_, err = c.Transform(obj)
+	require.ErrorContains(t, err, "overflows int64")
 }
 
 func renderedSpec(t *testing.T, name, namespace, filePath string, annotations map[string]interface{}) *spec.ResourceSpec {

--- a/pkg/resource/spec/patches_ai_test.go
+++ b/pkg/resource/spec/patches_ai_test.go
@@ -14,6 +14,24 @@ import (
 	"github.com/werf/nelm/pkg/resource/spec"
 )
 
+func TestAI_ApplyPatches_CancelledContextStopsInfiniteProgram(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "web"},
+	}}
+	meta := metaFor("Deployment", "apps", "v1", "web", "", "myapp/templates/web.yaml", nil, nil)
+
+	c, err := spec.CompilePatch(spec.Patch{Patch: `last(repeat(.))`})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = spec.ApplyPatches(ctx, []*spec.CompiledPatch{c}, meta, "prod", obj)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestAI_BuildRenderPatchedResourceSpecs_AllowsExplicitReleaseNamespace(t *testing.T) {
 	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
 
@@ -23,6 +41,19 @@ func TestAI_BuildRenderPatchedResourceSpecs_AllowsExplicitReleaseNamespace(t *te
 	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
 	require.NoError(t, err)
 	require.Empty(t, out[0].Unstruct.GetNamespace())
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_CancelledContextStopsInfiniteProgram(t *testing.T) {
+	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+	patches, err := spec.CompilePatches([]spec.Patch{{Patch: `def f: f; f`}})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = spec.BuildRenderPatchedResourceSpecs(ctx, "prod", []*spec.ResourceSpec{res}, patches)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestAI_BuildRenderPatchedResourceSpecs_ChainsRules(t *testing.T) {
@@ -271,6 +302,23 @@ func TestAI_BuildRenderPatchedResourceSpecs_RejectsNonStringMetadata(t *testing.
 	}
 }
 
+func TestAI_CompiledPatch_Transform_CancelledContextStopsInfiniteProgram(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "web"},
+	}}
+
+	c, err := spec.CompilePatch(spec.Patch{Patch: `def f: f; f`})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = c.Transform(ctx, obj)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestAI_CompiledPatch_Transform_KeepsFractional(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "apps/v1",
@@ -282,7 +330,7 @@ func TestAI_CompiledPatch_Transform_KeepsFractional(t *testing.T) {
 	c, err := spec.CompilePatch(spec.Patch{Patch: `.spec.ratio = 0.5`})
 	require.NoError(t, err)
 
-	out, err := c.Transform(obj)
+	out, err := c.Transform(context.Background(), obj)
 	require.NoError(t, err)
 	require.Equal(t, float64(0.5), out.Object["spec"].(map[string]interface{})["ratio"])
 }
@@ -298,28 +346,6 @@ func TestAI_CompiledPatch_Transform_RejectsIntegerOverflow(t *testing.T) {
 	c, err := spec.CompilePatch(spec.Patch{Patch: `.spec.big += 10`})
 	require.NoError(t, err)
 
-	_, err = c.Transform(obj)
+	_, err = c.Transform(context.Background(), obj)
 	require.ErrorContains(t, err, "overflows int64")
-}
-
-func renderedSpec(t *testing.T, name, namespace, filePath string, annotations map[string]interface{}) *spec.ResourceSpec {
-	t.Helper()
-
-	metadata := map[string]interface{}{"name": name}
-	if namespace != "" {
-		metadata["namespace"] = namespace
-	}
-
-	if annotations != nil {
-		metadata["annotations"] = annotations
-	}
-
-	unstruct := &unstructured.Unstructured{Object: map[string]interface{}{
-		"apiVersion": "apps/v1",
-		"kind":       "Deployment",
-		"metadata":   metadata,
-		"spec":       map[string]interface{}{"replicas": int64(3)},
-	}}
-
-	return spec.NewResourceSpec(unstruct, "prod", spec.ResourceSpecOptions{FilePath: filePath})
 }

--- a/pkg/resource/spec/patches_ai_test.go
+++ b/pkg/resource/spec/patches_ai_test.go
@@ -1,0 +1,225 @@
+//go:build ai_tests
+
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/werf/nelm/pkg/common"
+	"github.com/werf/nelm/pkg/resource/spec"
+)
+
+func TestAI_BuildRenderPatchedResourceSpecs_AllowsExplicitReleaseNamespace(t *testing.T) {
+	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+	patches, err := spec.CompilePatches([]spec.Patch{{Patch: `.metadata.namespace = "prod"`}})
+	require.NoError(t, err)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+	require.NoError(t, err)
+	require.Empty(t, out[0].Unstruct.GetNamespace())
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_ChainsRules(t *testing.T) {
+	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+	patches, err := spec.CompilePatches([]spec.Patch{
+		{Patch: `.spec.replicas = 5`},
+		{Patch: `.spec.replicas += 1`},
+	})
+	require.NoError(t, err)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+	require.NoError(t, err)
+
+	replicas, _, err := unstructured.NestedInt64(out[0].Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.Equal(t, int64(6), replicas)
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_ChartScope(t *testing.T) {
+	inScope := renderedSpec(t, "cached", "", "myapp/charts/cache/templates/web.yaml", nil)
+	outOfScope := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+	patches, err := spec.CompilePatches([]spec.Patch{{
+		ChartScope: "myapp/charts/cache",
+		Patch:      `del(.spec.replicas)`,
+	}})
+	require.NoError(t, err)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{inScope, outOfScope}, patches)
+	require.NoError(t, err)
+
+	_, found, err := unstructured.NestedInt64(out[0].Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	_, found, err = unstructured.NestedInt64(out[1].Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.True(t, found)
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_ContractViolations(t *testing.T) {
+	tests := []struct {
+		name    string
+		program string
+	}{
+		{name: "no output", program: `empty`},
+		{name: "multiple outputs", program: `., .`},
+		{name: "not an object", program: `.metadata.name`},
+		{name: "an object that is not a resource", program: `.spec`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+			patches, err := spec.CompilePatches([]spec.Patch{{Patch: tt.program}})
+			require.NoError(t, err)
+
+			_, err = spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+			require.ErrorContains(t, err, "apply render patches to resource")
+		})
+	}
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_NamespaceSelector(t *testing.T) {
+	// A resource without an explicit namespace ends up in the release namespace, so it is
+	// matched by a selector naming the release namespace.
+	releaseNamespaced := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+	otherNamespaced := renderedSpec(t, "web", "other", "myapp/templates/other.yaml", nil)
+
+	patches, err := spec.CompilePatches([]spec.Patch{{
+		Match: spec.ResourceMatcher{Namespaces: []string{"prod"}},
+		Patch: `del(.spec.replicas)`,
+	}})
+	require.NoError(t, err)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{releaseNamespaced, otherNamespaced}, patches)
+	require.NoError(t, err)
+
+	_, found, err := unstructured.NestedInt64(out[0].Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	_, found, err = unstructured.NestedInt64(out[1].Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.True(t, found)
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_NoPatches(t *testing.T) {
+	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []*spec.ResourceSpec{res}, out)
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_PatchesMatchedOnly(t *testing.T) {
+	deployment := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+	secret := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": "creds"},
+		"data":       map[string]interface{}{"key": "dmFsdWU="},
+	}}
+	secretSpec := spec.NewResourceSpec(secret, "prod", spec.ResourceSpecOptions{FilePath: "myapp/templates/creds.yaml"})
+
+	patches, err := spec.CompilePatches([]spec.Patch{{
+		Match: spec.ResourceMatcher{Kinds: []string{"Deployment"}},
+		Patch: `.spec.replicas = 5`,
+	}})
+	require.NoError(t, err)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{deployment, secretSpec}, patches)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	replicas, found, err := unstructured.NestedInt64(out[0].Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(5), replicas)
+
+	require.Equal(t, secret.Object, out[1].Unstruct.Object)
+
+	// The input specs are never mutated.
+	inputReplicas, _, err := unstructured.NestedInt64(deployment.Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), inputReplicas)
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_RederivesStoreAs(t *testing.T) {
+	t.Run("adding the hook annotation turns a regular resource into a hook", func(t *testing.T) {
+		res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+		require.Equal(t, common.StoreAsRegular, res.StoreAs)
+
+		patches, err := spec.CompilePatches([]spec.Patch{{Patch: `.metadata.annotations["helm.sh/hook"] = "post-install"`}})
+		require.NoError(t, err)
+
+		out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+		require.NoError(t, err)
+		require.Equal(t, common.StoreAsHook, out[0].StoreAs)
+	})
+
+	t.Run("removing the hook annotation turns a hook into a regular resource", func(t *testing.T) {
+		res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", map[string]interface{}{"helm.sh/hook": "post-install"})
+		require.Equal(t, common.StoreAsHook, res.StoreAs)
+
+		patches, err := spec.CompilePatches([]spec.Patch{{Patch: `del(.metadata.annotations["helm.sh/hook"])`}})
+		require.NoError(t, err)
+
+		out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+		require.NoError(t, err)
+		require.Equal(t, common.StoreAsRegular, out[0].StoreAs)
+	})
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_RejectsIdentityChange(t *testing.T) {
+	tests := []struct {
+		name    string
+		program string
+	}{
+		{name: "name", program: `.metadata.name = "other"`},
+		{name: "kind", program: `.kind = "StatefulSet"`},
+		{name: "apiVersion", program: `.apiVersion = "apps/v1beta1"`},
+		{name: "namespace", program: `.metadata.namespace = "other"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+			patches, err := spec.CompilePatches([]spec.Patch{{Patch: tt.program}})
+			require.NoError(t, err)
+
+			_, err = spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+			require.ErrorContains(t, err, "changed resource identity")
+		})
+	}
+}
+
+func renderedSpec(t *testing.T, name, namespace, filePath string, annotations map[string]interface{}) *spec.ResourceSpec {
+	t.Helper()
+
+	metadata := map[string]interface{}{"name": name}
+	if namespace != "" {
+		metadata["namespace"] = namespace
+	}
+
+	if annotations != nil {
+		metadata["annotations"] = annotations
+	}
+
+	unstruct := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   metadata,
+		"spec":       map[string]interface{}{"replicas": int64(3)},
+	}}
+
+	return spec.NewResourceSpec(unstruct, "prod", spec.ResourceSpecOptions{FilePath: filePath})
+}

--- a/pkg/resource/spec/patches_ai_test.go
+++ b/pkg/resource/spec/patches_ai_test.go
@@ -41,6 +41,23 @@ func TestAI_BuildRenderPatchedResourceSpecs_ChainsRules(t *testing.T) {
 	require.Equal(t, int64(6), replicas)
 }
 
+func TestAI_BuildRenderPatchedResourceSpecs_ChainsRulesByMetadata(t *testing.T) {
+	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+	patches, err := spec.CompilePatches([]spec.Patch{
+		{Patch: `.metadata.labels = {"tier": "backend"}`},
+		{Match: spec.ResourceMatcher{Labels: map[string]string{"tier": "backend"}}, Patch: `.spec.replicas = 7`},
+	})
+	require.NoError(t, err)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+	require.NoError(t, err)
+
+	replicas, _, err := unstructured.NestedInt64(out[0].Unstruct.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.Equal(t, int64(7), replicas)
+}
+
 func TestAI_BuildRenderPatchedResourceSpecs_ChartScope(t *testing.T) {
 	inScope := renderedSpec(t, "cached", "", "myapp/charts/cache/templates/web.yaml", nil)
 	outOfScope := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
@@ -152,6 +169,24 @@ func TestAI_BuildRenderPatchedResourceSpecs_PatchesMatchedOnly(t *testing.T) {
 	require.Equal(t, int64(3), inputReplicas)
 }
 
+func TestAI_BuildRenderPatchedResourceSpecs_PreservesStoreAsNone(t *testing.T) {
+	res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+	crd := spec.NewResourceSpec(res.Unstruct, "prod", spec.ResourceSpecOptions{
+		FilePath: "myapp/crds/foo.yaml",
+		StoreAs:  common.StoreAsNone,
+	})
+
+	patches, err := spec.CompilePatches([]spec.Patch{
+		{Match: spec.ResourceMatcher{Names: []string{"nonexistent"}}, Patch: `.spec.replicas = 5`},
+		{Patch: `.metadata.annotations["helm.sh/hook"] = "post-install"`},
+	})
+	require.NoError(t, err)
+
+	out, err := spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{crd}, patches)
+	require.NoError(t, err)
+	require.Equal(t, common.StoreAsNone, out[0].StoreAs)
+}
+
 func TestAI_BuildRenderPatchedResourceSpecs_RederivesStoreAs(t *testing.T) {
 	t.Run("adding the hook annotation turns a regular resource into a hook", func(t *testing.T) {
 		res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
@@ -198,6 +233,28 @@ func TestAI_BuildRenderPatchedResourceSpecs_RejectsIdentityChange(t *testing.T) 
 
 			_, err = spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
 			require.ErrorContains(t, err, "changed resource identity")
+		})
+	}
+}
+
+func TestAI_BuildRenderPatchedResourceSpecs_RejectsNonStringMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		program string
+	}{
+		{name: "annotations", program: `.metadata.annotations = {"werf.io/weight": 10}`},
+		{name: "labels", program: `.metadata.labels = {"app": true}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := renderedSpec(t, "web", "", "myapp/templates/web.yaml", nil)
+
+			patches, err := spec.CompilePatches([]spec.Patch{{Patch: tt.program}})
+			require.NoError(t, err)
+
+			_, err = spec.BuildRenderPatchedResourceSpecs(context.Background(), "prod", []*spec.ResourceSpec{res}, patches)
+			require.ErrorContains(t, err, "expected string")
 		})
 	}
 }

--- a/pkg/resource/spec/patches_internal_ai_test.go
+++ b/pkg/resource/spec/patches_internal_ai_test.go
@@ -1,0 +1,15 @@
+//go:build ai_tests
+
+package spec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_normalizeNumbers_ErrorsOnUnrepresentableNumber(t *testing.T) {
+	_, err := normalizeNumbers(json.Number("1e10000"))
+	require.ErrorContains(t, err, "cannot be represented as int64 or float64")
+}

--- a/pkg/resource/spec/patches_test.go
+++ b/pkg/resource/spec/patches_test.go
@@ -1,6 +1,7 @@
 package spec_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +26,7 @@ func TestApplyPatches(t *testing.T) {
 	meta := metaFor("Deployment", "apps", "v1", "web", "", "myapp/templates/web.yaml", nil, nil)
 
 	t.Run("no rules returns unchanged deep copy", func(t *testing.T) {
-		out, err := spec.ApplyPatches(nil, meta, "prod", obj)
+		out, err := spec.ApplyPatches(context.Background(), nil, meta, "prod", obj)
 		require.NoError(t, err)
 		require.Equal(t, obj.Object, out.Object)
 		require.NotSame(t, &obj.Object, &out.Object)
@@ -38,7 +39,7 @@ func TestApplyPatches(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		out, err := spec.ApplyPatches([]*spec.CompiledPatch{c}, meta, "prod", obj)
+		out, err := spec.ApplyPatches(context.Background(), []*spec.CompiledPatch{c}, meta, "prod", obj)
 		require.NoError(t, err)
 		require.Equal(t, int64(3), out.Object["spec"].(map[string]interface{})["replicas"])
 	})
@@ -49,7 +50,7 @@ func TestApplyPatches(t *testing.T) {
 		c2, err := spec.CompilePatch(spec.Patch{Patch: `.metadata.name = "patched"`})
 		require.NoError(t, err)
 
-		out, err := spec.ApplyPatches([]*spec.CompiledPatch{c1, c2}, meta, "prod", obj)
+		out, err := spec.ApplyPatches(context.Background(), []*spec.CompiledPatch{c1, c2}, meta, "prod", obj)
 		require.NoError(t, err)
 
 		_, hasReplicas := out.Object["spec"].(map[string]interface{})["replicas"]
@@ -366,7 +367,7 @@ func TestCompiledPatch_Transform(t *testing.T) {
 		c, err := spec.CompilePatch(spec.Patch{Patch: "del(.spec.replicas)"})
 		require.NoError(t, err)
 
-		out, err := c.Transform(obj)
+		out, err := c.Transform(context.Background(), obj)
 		require.NoError(t, err)
 
 		outSpec := out.Object["spec"].(map[string]interface{})
@@ -397,7 +398,7 @@ func TestCompiledPatch_Transform(t *testing.T) {
 			c, err := spec.CompilePatch(spec.Patch{Patch: tt.program})
 			require.NoError(t, err)
 
-			out, err := c.Transform(obj)
+			out, err := c.Transform(context.Background(), obj)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, out.Object["spec"].(map[string]interface{})["replicas"])
 		})
@@ -419,7 +420,7 @@ func TestCompiledPatch_Transform(t *testing.T) {
 			c, err := spec.CompilePatch(spec.Patch{Patch: tt.program})
 			require.NoError(t, err)
 
-			_, err = c.Transform(obj)
+			_, err = c.Transform(context.Background(), obj)
 			require.Error(t, err)
 		})
 	}

--- a/pkg/resource/spec/patches_test.go
+++ b/pkg/resource/spec/patches_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/werf/nelm/pkg/resource/spec"
 )
 
-func TestApplyDiffPatches(t *testing.T) {
+func TestApplyPatches(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
@@ -25,31 +25,31 @@ func TestApplyDiffPatches(t *testing.T) {
 	meta := metaFor("Deployment", "apps", "v1", "web", "", "myapp/templates/web.yaml", nil, nil)
 
 	t.Run("no rules returns unchanged deep copy", func(t *testing.T) {
-		out, err := spec.ApplyDiffPatches(nil, meta, "prod", obj)
+		out, err := spec.ApplyPatches(nil, meta, "prod", obj)
 		require.NoError(t, err)
 		require.Equal(t, obj.Object, out.Object)
 		require.NotSame(t, &obj.Object, &out.Object)
 	})
 
 	t.Run("non-matching rule leaves object unchanged", func(t *testing.T) {
-		c, err := spec.CompileDiffPatch(spec.DiffPatch{
+		c, err := spec.CompilePatch(spec.Patch{
 			Match: spec.ResourceMatcher{Names: []string{"other"}},
 			Patch: "del(.spec.replicas)",
 		})
 		require.NoError(t, err)
 
-		out, err := spec.ApplyDiffPatches([]*spec.CompiledDiffPatch{c}, meta, "prod", obj)
+		out, err := spec.ApplyPatches([]*spec.CompiledPatch{c}, meta, "prod", obj)
 		require.NoError(t, err)
 		require.Equal(t, int64(3), out.Object["spec"].(map[string]interface{})["replicas"])
 	})
 
 	t.Run("matching rules chain in order", func(t *testing.T) {
-		c1, err := spec.CompileDiffPatch(spec.DiffPatch{Patch: "del(.spec.replicas)"})
+		c1, err := spec.CompilePatch(spec.Patch{Patch: "del(.spec.replicas)"})
 		require.NoError(t, err)
-		c2, err := spec.CompileDiffPatch(spec.DiffPatch{Patch: `.metadata.name = "patched"`})
+		c2, err := spec.CompilePatch(spec.Patch{Patch: `.metadata.name = "patched"`})
 		require.NoError(t, err)
 
-		out, err := spec.ApplyDiffPatches([]*spec.CompiledDiffPatch{c1, c2}, meta, "prod", obj)
+		out, err := spec.ApplyPatches([]*spec.CompiledPatch{c1, c2}, meta, "prod", obj)
 		require.NoError(t, err)
 
 		_, hasReplicas := out.Object["spec"].(map[string]interface{})["replicas"]
@@ -61,56 +61,62 @@ func TestApplyDiffPatches(t *testing.T) {
 func TestCollectChartPatches_NilChart(t *testing.T) {
 	patches, err := spec.CollectChartPatches(nil)
 	require.NoError(t, err)
-	require.Empty(t, patches)
+	require.Empty(t, patches.Diff)
+	require.Empty(t, patches.Render)
 }
 
 func TestCollectChartPatches_ScopingAndOrder(t *testing.T) {
 	// Tree: app (root) -> [cache subchart]
-	cache := chartWithPatches("cache", "diffPatches:\n- patch: del(.cacheField)\n")
-	app := chartWithPatches("app", "diffPatches:\n- patch: del(.appField)\n", cache)
+	cache := chartWithPatches("cache", "diffPatches:\n- patch: del(.cacheField)\nrenderPatches:\n- patch: del(.cacheRendered)\n")
+	app := chartWithPatches("app", "diffPatches:\n- patch: del(.appField)\nrenderPatches:\n- patch: del(.appRendered)\n", cache)
 
 	accessor, err := helmchart.NewAccessor(app)
 	require.NoError(t, err)
 
 	patches, err := spec.CollectChartPatches(accessor)
 	require.NoError(t, err)
-	require.Len(t, patches, 2)
+	require.Len(t, patches.Diff, 2)
+	require.Len(t, patches.Render, 2)
 
 	// Leaf-first ordering: subchart (cache) rule before parent (app) rule.
-	require.Equal(t, "del(.cacheField)", patches[0].Patch)
-	require.Equal(t, "del(.appField)", patches[1].Patch)
+	require.Equal(t, "del(.cacheField)", patches.Diff[0].Patch)
+	require.Equal(t, "del(.appField)", patches.Diff[1].Patch)
+	require.Equal(t, "del(.cacheRendered)", patches.Render[0].Patch)
+	require.Equal(t, "del(.appRendered)", patches.Render[1].Patch)
 
 	// Scoping: subchart rule constrained to its subtree; parent rule to the root.
-	require.Equal(t, "app/charts/cache", patches[0].ChartScope)
-	require.Equal(t, "app", patches[1].ChartScope)
+	require.Equal(t, "app/charts/cache", patches.Diff[0].ChartScope)
+	require.Equal(t, "app", patches.Diff[1].ChartScope)
+	require.Equal(t, "app/charts/cache", patches.Render[0].ChartScope)
+	require.Equal(t, "app", patches.Render[1].ChartScope)
 }
 
-func TestCompileDiffPatch_DefaultsType(t *testing.T) {
-	c, err := spec.CompileDiffPatch(spec.DiffPatch{Patch: "."})
+func TestCompilePatch_DefaultsType(t *testing.T) {
+	c, err := spec.CompilePatch(spec.Patch{Patch: "."})
 	require.NoError(t, err)
 	require.NotNil(t, c)
 }
 
-func TestCompileDiffPatch_FailsClosed(t *testing.T) {
+func TestCompilePatch_FailsClosed(t *testing.T) {
 	tests := []struct {
 		name  string
-		patch spec.DiffPatch
+		patch spec.Patch
 	}{
 		{
 			name:  "invalid jq program",
-			patch: spec.DiffPatch{Patch: "del(.spec.replicas"},
+			patch: spec.Patch{Patch: "del(.spec.replicas"},
 		},
 		{
 			name:  "empty patch body",
-			patch: spec.DiffPatch{Patch: "   "},
+			patch: spec.Patch{Patch: "   "},
 		},
 		{
 			name:  "unsupported type",
-			patch: spec.DiffPatch{Type: "jsonPointer", Patch: "."},
+			patch: spec.Patch{Type: "jsonPointer", Patch: "."},
 		},
 		{
 			name: "invalid regexp in selector",
-			patch: spec.DiffPatch{
+			patch: spec.Patch{
 				Match: spec.ResourceMatcher{Names: []string{"/(/"}},
 				Patch: ".",
 			},
@@ -119,13 +125,13 @@ func TestCompileDiffPatch_FailsClosed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := spec.CompileDiffPatch(tt.patch)
+			_, err := spec.CompilePatch(tt.patch)
 			require.Error(t, err)
 		})
 	}
 }
 
-func TestCompiledDiffPatch_ChartScope(t *testing.T) {
+func TestCompiledPatch_ChartScope(t *testing.T) {
 	scope := "app/charts/cache"
 	tests := []struct {
 		name     string
@@ -141,7 +147,7 @@ func TestCompiledDiffPatch_ChartScope(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := spec.CompileDiffPatch(spec.DiffPatch{ChartScope: scope, Patch: "."})
+			c, err := spec.CompilePatch(spec.Patch{ChartScope: scope, Patch: "."})
 			require.NoError(t, err)
 
 			meta := metaFor("Deployment", "apps", "v1", "web", "", tt.filePath, nil, nil)
@@ -150,7 +156,7 @@ func TestCompiledDiffPatch_ChartScope(t *testing.T) {
 	}
 }
 
-func TestCompiledDiffPatch_Match(t *testing.T) {
+func TestCompiledPatch_Match(t *testing.T) {
 	tests := []struct {
 		name      string
 		selector  spec.ResourceMatcher
@@ -339,14 +345,14 @@ func TestCompiledDiffPatch_Match(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := spec.CompileDiffPatch(spec.DiffPatch{Match: tt.selector, Patch: "."})
+			c, err := spec.CompilePatch(spec.Patch{Match: tt.selector, Patch: "."})
 			require.NoError(t, err)
 			require.Equal(t, tt.want, c.Match(tt.meta, tt.namespace))
 		})
 	}
 }
 
-func TestCompiledDiffPatch_Transform(t *testing.T) {
+func TestCompiledPatch_Transform(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
@@ -357,7 +363,7 @@ func TestCompiledDiffPatch_Transform(t *testing.T) {
 	}}
 
 	t.Run("happy path removes field without mutating input", func(t *testing.T) {
-		c, err := spec.CompileDiffPatch(spec.DiffPatch{Patch: "del(.spec.replicas)"})
+		c, err := spec.CompilePatch(spec.Patch{Patch: "del(.spec.replicas)"})
 		require.NoError(t, err)
 
 		out, err := c.Transform(obj)
@@ -388,7 +394,7 @@ func TestCompiledDiffPatch_Transform(t *testing.T) {
 
 	for _, tt := range numeric {
 		t.Run("numeric "+tt.name, func(t *testing.T) {
-			c, err := spec.CompileDiffPatch(spec.DiffPatch{Patch: tt.program})
+			c, err := spec.CompilePatch(spec.Patch{Patch: tt.program})
 			require.NoError(t, err)
 
 			out, err := c.Transform(obj)
@@ -410,7 +416,7 @@ func TestCompiledDiffPatch_Transform(t *testing.T) {
 
 	for _, tt := range failures {
 		t.Run("rejects "+tt.name, func(t *testing.T) {
-			c, err := spec.CompileDiffPatch(spec.DiffPatch{Patch: tt.program})
+			c, err := spec.CompilePatch(spec.Patch{Patch: tt.program})
 			require.NoError(t, err)
 
 			_, err = c.Transform(obj)
@@ -424,33 +430,41 @@ func TestLoadPatchesFiles(t *testing.T) {
 	a := filepath.Join(dir, "a.yaml")
 	b := filepath.Join(dir, "b.yaml")
 
-	require.NoError(t, os.WriteFile(a, []byte("diffPatches:\n- patch: del(.a)\n"), 0o644))
+	require.NoError(t, os.WriteFile(a, []byte("diffPatches:\n- patch: del(.a)\nrenderPatches:\n- patch: del(.renderedA)\n"), 0o644))
 	require.NoError(t, os.WriteFile(b, []byte("diffPatches:\n- patch: del(.b)\n"), 0o644))
 
 	patches, err := spec.LoadPatchesFiles([]string{a, b})
 	require.NoError(t, err)
-	require.Len(t, patches, 2)
-	require.Equal(t, "del(.a)", patches[0].Patch)
-	require.Equal(t, "del(.b)", patches[1].Patch)
+	require.Len(t, patches.Diff, 2)
+	require.Equal(t, "del(.a)", patches.Diff[0].Patch)
+	require.Equal(t, "del(.b)", patches.Diff[1].Patch)
+	require.Len(t, patches.Render, 1)
+	require.Equal(t, "del(.renderedA)", patches.Render[0].Patch)
 
 	_, err = spec.LoadPatchesFiles([]string{filepath.Join(dir, "missing.yaml")})
 	require.Error(t, err)
 }
 
 func TestParsePatchesFile(t *testing.T) {
-	t.Run("parses diffPatches", func(t *testing.T) {
+	t.Run("parses both patch kinds", func(t *testing.T) {
 		data := []byte(`
 diffPatches:
 - match:
     kinds: [Deployment]
   patch: del(.spec.replicas)
 - patch: del(.data.foo)
+renderPatches:
+- match:
+    kinds: [StatefulSet]
+  patch: del(.spec.template.spec.nodeSelector)
 `)
 		patches, err := spec.ParsePatchesFile(data)
 		require.NoError(t, err)
-		require.Len(t, patches, 2)
-		require.Equal(t, []string{"Deployment"}, patches[0].Match.Kinds)
-		require.Equal(t, "del(.spec.replicas)", patches[0].Patch)
+		require.Len(t, patches.Diff, 2)
+		require.Equal(t, []string{"Deployment"}, patches.Diff[0].Match.Kinds)
+		require.Equal(t, "del(.spec.replicas)", patches.Diff[0].Patch)
+		require.Len(t, patches.Render, 1)
+		require.Equal(t, []string{"StatefulSet"}, patches.Render[0].Match.Kinds)
 	})
 
 	t.Run("rejects unknown top-level key", func(t *testing.T) {
@@ -461,7 +475,8 @@ diffPatches:
 	t.Run("empty file yields no patches", func(t *testing.T) {
 		patches, err := spec.ParsePatchesFile([]byte("{}\n"))
 		require.NoError(t, err)
-		require.Empty(t, patches)
+		require.Empty(t, patches.Diff)
+		require.Empty(t, patches.Render)
 	})
 }
 

--- a/pkg/resource/spec/resource_spec.go
+++ b/pkg/resource/spec/resource_spec.go
@@ -164,7 +164,7 @@ func BuildRenderPatchedResourceSpecs(ctx context.Context, releaseNamespace strin
 				continue
 			}
 
-			out, err := patch.transform(patchedUnstruct)
+			out, err := patch.transform(ctx, patchedUnstruct)
 			if err != nil {
 				return nil, fmt.Errorf("apply render patches to resource %q: patch #%d: %w", res.IDHuman(), i+1, err)
 			}

--- a/pkg/resource/spec/resource_spec.go
+++ b/pkg/resource/spec/resource_spec.go
@@ -62,14 +62,8 @@ func NewResourceSpecFromManifest(ctx context.Context, manifest, releaseNamespace
 	if opts.DropInvalidAnnotationsAndLabels {
 		unstruct.SetAnnotations(stripInvalidEntries(ctx, opts.FilePath, unstruct.Object, "metadata", "annotations"))
 		unstruct.SetLabels(stripInvalidEntries(ctx, opts.FilePath, unstruct.Object, "metadata", "labels"))
-	} else {
-		if _, _, err := unstructured.NestedNullCoercingStringMap(unstruct.Object, "metadata", "annotations"); err != nil {
-			return nil, fmt.Errorf("decode resource (file: %q): %w", opts.FilePath, err)
-		}
-
-		if _, _, err := unstructured.NestedNullCoercingStringMap(unstruct.Object, "metadata", "labels"); err != nil {
-			return nil, fmt.Errorf("decode resource (file: %q): %w", opts.FilePath, err)
-		}
+	} else if err := validateMetadataStringMaps(unstruct); err != nil {
+		return nil, fmt.Errorf("decode resource (file: %q): %w", opts.FilePath, err)
 	}
 
 	return NewResourceSpec(unstruct, releaseNamespace, opts), nil
@@ -148,7 +142,7 @@ func BuildPatchedResourceSpecs(ctx context.Context, releaseNamespace string, tra
 // Patch ResourceSpecs with render patches, i.e. right after the chart is rendered. Unlike diff
 // patches, the result is what gets released and applied to the cluster, so a patch must not change
 // the resource identity. StoreAs is re-derived, because a patch can add or remove the Helm hook
-// annotation.
+// annotation, except for StoreAsNone, which is not releasable at all and must survive patching.
 func BuildRenderPatchedResourceSpecs(ctx context.Context, releaseNamespace string, resources []*ResourceSpec, patches []*CompiledPatch) ([]*ResourceSpec, error) {
 	if len(patches) == 0 {
 		return resources, nil
@@ -157,14 +151,30 @@ func BuildRenderPatchedResourceSpecs(ctx context.Context, releaseNamespace strin
 	patchedResources := make([]*ResourceSpec, 0, len(resources))
 
 	for _, res := range resources {
-		// There is no live object at render time to take the true namespace from, and namespaced
-		// resources without an explicit namespace end up in the release namespace, so
-		// cluster-scoped resources are indistinguishable from them here.
-		namespace := lo.Ternary(res.Unstruct.GetNamespace() == "", releaseNamespace, res.Unstruct.GetNamespace())
+		patchedUnstruct := res.Unstruct
+		patchedMeta := res.ResourceMeta
 
-		patchedUnstruct, err := ApplyPatches(patches, res.ResourceMeta, namespace, res.Unstruct)
-		if err != nil {
-			return nil, fmt.Errorf("apply render patches to resource %q: %w", res.IDHuman(), err)
+		for i, patch := range patches {
+			// There is no live object at render time to take the true namespace from, and
+			// namespaced resources without an explicit namespace end up in the release namespace,
+			// so cluster-scoped resources are indistinguishable from them here.
+			namespace := lo.Ternary(patchedUnstruct.GetNamespace() == "", releaseNamespace, patchedUnstruct.GetNamespace())
+
+			if !patch.Match(patchedMeta, namespace) {
+				continue
+			}
+
+			out, err := patch.transform(patchedUnstruct)
+			if err != nil {
+				return nil, fmt.Errorf("apply render patches to resource %q: patch #%d: %w", res.IDHuman(), i+1, err)
+			}
+
+			if err := validateMetadataStringMaps(out); err != nil {
+				return nil, fmt.Errorf("apply render patches to resource %q: patch #%d: %w", res.IDHuman(), i+1, err)
+			}
+
+			patchedUnstruct = out
+			patchedMeta = NewResourceMetaFromUnstructured(patchedUnstruct, releaseNamespace, res.FilePath)
 		}
 
 		if err := validateSameResourceIdentity(res.Unstruct, patchedUnstruct, releaseNamespace); err != nil {
@@ -173,6 +183,7 @@ func BuildRenderPatchedResourceSpecs(ctx context.Context, releaseNamespace strin
 
 		patchedResources = append(patchedResources, NewResourceSpec(patchedUnstruct, releaseNamespace, ResourceSpecOptions{
 			FilePath: res.FilePath,
+			StoreAs:  lo.Ternary(res.StoreAs == common.StoreAsNone, common.StoreAsNone, common.StoreAs("")),
 		}))
 	}
 
@@ -216,6 +227,18 @@ func BuildTransformedResourceSpecs(ctx context.Context, releaseNamespace string,
 	}
 
 	return transformedResources, nil
+}
+
+// Annotations and labels are read via apimachinery accessors, which silently discard non-string
+// values, so anything but a string map must be rejected before the resource is used.
+func validateMetadataStringMaps(unstruct *unstructured.Unstructured) error {
+	for _, field := range []string{"annotations", "labels"} {
+		if _, _, err := unstructured.NestedNullCoercingStringMap(unstruct.Object, "metadata", field); err != nil {
+			return fmt.Errorf("validate resource metadata: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func validateSameResourceIdentity(original, patched *unstructured.Unstructured, releaseNamespace string) error {

--- a/pkg/resource/spec/resource_spec.go
+++ b/pkg/resource/spec/resource_spec.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -144,6 +145,40 @@ func BuildPatchedResourceSpecs(ctx context.Context, releaseNamespace string, tra
 	return releasableResources, nil
 }
 
+// Patch ResourceSpecs with render patches, i.e. right after the chart is rendered. Unlike diff
+// patches, the result is what gets released and applied to the cluster, so a patch must not change
+// the resource identity. StoreAs is re-derived, because a patch can add or remove the Helm hook
+// annotation.
+func BuildRenderPatchedResourceSpecs(ctx context.Context, releaseNamespace string, resources []*ResourceSpec, patches []*CompiledPatch) ([]*ResourceSpec, error) {
+	if len(patches) == 0 {
+		return resources, nil
+	}
+
+	patchedResources := make([]*ResourceSpec, 0, len(resources))
+
+	for _, res := range resources {
+		// There is no live object at render time to take the true namespace from, and namespaced
+		// resources without an explicit namespace end up in the release namespace, so
+		// cluster-scoped resources are indistinguishable from them here.
+		namespace := lo.Ternary(res.Unstruct.GetNamespace() == "", releaseNamespace, res.Unstruct.GetNamespace())
+
+		patchedUnstruct, err := ApplyPatches(patches, res.ResourceMeta, namespace, res.Unstruct)
+		if err != nil {
+			return nil, fmt.Errorf("apply render patches to resource %q: %w", res.IDHuman(), err)
+		}
+
+		if err := validateSameResourceIdentity(res.Unstruct, patchedUnstruct, releaseNamespace); err != nil {
+			return nil, fmt.Errorf("apply render patches to resource %q: %w", res.IDHuman(), err)
+		}
+
+		patchedResources = append(patchedResources, NewResourceSpec(patchedUnstruct, releaseNamespace, ResourceSpecOptions{
+			FilePath: res.FilePath,
+		}))
+	}
+
+	return patchedResources, nil
+}
+
 // Transforms ResourceSpecs, which means specs can be added, deleted, expanded (like Lists). If you
 // just need to modify specs, use patchers in BuildReleasableResourceSpecs instead.
 func BuildTransformedResourceSpecs(ctx context.Context, releaseNamespace string, resources []*ResourceSpec, transformers []ResourceTransformer) ([]*ResourceSpec, error) {
@@ -181,4 +216,25 @@ func BuildTransformedResourceSpecs(ctx context.Context, releaseNamespace string,
 	}
 
 	return transformedResources, nil
+}
+
+func validateSameResourceIdentity(original, patched *unstructured.Unstructured, releaseNamespace string) error {
+	if patched.GetAPIVersion() == "" || patched.GetKind() == "" || patched.GetName() == "" {
+		return fmt.Errorf("patch output is not a resource: apiVersion, kind or name is missing")
+	}
+
+	originalNamespace := lo.Ternary(original.GetNamespace() == "", releaseNamespace, original.GetNamespace())
+	patchedNamespace := lo.Ternary(patched.GetNamespace() == "", releaseNamespace, patched.GetNamespace())
+
+	if original.GetAPIVersion() == patched.GetAPIVersion() &&
+		original.GetKind() == patched.GetKind() &&
+		original.GetName() == patched.GetName() &&
+		originalNamespace == patchedNamespace {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"patch changed resource identity to apiVersion %q, kind %q, name %q, namespace %q, which is not allowed",
+		patched.GetAPIVersion(), patched.GetKind(), patched.GetName(), patchedNamespace,
+	)
 }


### PR DESCRIPTION
## Summary

Adds a second kind of rule to `patches.yaml` / `--patches`: `renderPatches`, applied to the rendered
resources right after the chart is rendered. Unlike `diffPatches`, which only normalize the live and
dry-apply objects before they are compared, render patches change what goes into the release and to
the cluster — a way to fix up a resource you do not own (a subchart's manifest, a field a controller
fights over, metadata a policy engine demands) without forking templates.

## Key changes

- New `renderPatches` top-level key, next to `diffPatches`, in both chart-shipped `patches.yaml` and
  `--patches` files: same rule shape (`match`, `type: jq`, `patch`), same chart-subtree scoping for
  chart-shipped rules, same "jq program must return exactly one object" contract.
- New pipeline stage `spec.BuildRenderPatchedResourceSpecs`, placed after list expansion and before
  the existing patchers, so rules match real resources and nelm's own metadata lands on top of user
  patches. Semantics specific to render patches:
  - a patch may not change the resource identity (`apiVersion`/`kind`/`name`/`namespace`), and output
    that is not a resource at all is rejected outright;
  - `metadata.annotations` and `metadata.labels` in the output must be string maps, the same check the
    manifest decoder does: a non-string value (`.metadata.annotations["werf.io/weight"] = 10`) is
    rejected instead of being silently dropped by the apimachinery accessors, which would leave
    `ResourceMeta` without the annotations while the object keeps the bad value;
  - `StoreAs` is re-derived from the patched object, so adding or removing `helm.sh/hook` in a render
    patch really does reclassify the resource. `StoreAsNone`, carried by standalone CRDs, is exempt
    and survives patching — it is not releasable at all, and without the exemption a single render
    rule anywhere would turn every standalone CRD into a released, release-owned resource;
  - rules are applied in order and each matches against the result of the preceding ones, so a rule
    can key off a label or annotation an earlier rule added. `ApplyPatches` is deliberately not
    reused for this: its matchers must keep seeing the unpatched resource, so that diff patches take
    the same rule path for the live and the dry-apply object.
- Patch machinery renamed to be kind-neutral (`DiffPatch`→`Patch`, `CompiledDiffPatch`→`CompiledPatch`,
  `ApplyDiffPatches`→`ApplyPatches`, `diff_patch.go`→`patches.go`): matching, compiling and
  transforming were never diff-specific, only the point of application is.
- User jq programs are cancellable: `CompiledPatch.transform` runs gojq via `RunWithContext`, and
  `ApplyPatches` takes a `context.Context`, threaded from the operation context in both the render
  stage and the live/dry-apply diff paths — a looping patch (`def f: f; f`) now aborts on Ctrl-C or
  command timeout with `context.Canceled` instead of hanging nelm. Matters more with this PR, since
  `chart render`/`chart lint` now execute user jq locally.
- One resolve-and-compile point: `resolvePatches` collects chart-shipped and file rules and compiles
  both kinds immediately, so a bad regexp or jq program fails before anything is written into a
  release or sent to the cluster. `plan.BuildResourceInfosOptions.DiffPatches` now takes compiled
  patches and the compile step inside `BuildResourceInfos` is gone.
- Wiring: render patches apply in `release install`, `release plan install`, `chart render` and
  `chart lint`. `release rollback`, `release uninstall` and the rollback-on-failure path render
  nothing, so they use diff patches only and ignore render rules silently instead of erroring — the
  rules were already baked into the stored release, and the same patches file has to work for every
  command.
- `--patches` and `--no-default-patches` added to `chart render` and `chart lint`, which had no patch
  flags at all; `chart lint` now also honours diff patches, which it silently dropped before.
- Docs and tests: `docs/reference.md` regenerated; existing patch tests moved to the new names and
  extended to cover both kinds; new `patches_ai_test.go` covers matching, chart scope, namespace
  handling, identity rejection, `StoreAs` re-derivation and the `StoreAsNone` exemption, chaining by
  patched metadata, non-string annotations/labels, and contract violations, plus cancellation of an
  infinite jq program through `Transform`, `ApplyPatches` and `BuildRenderPatchedResourceSpecs`.

## Why

`diffPatches` can only hide drift — there was no supported way to adjust a rendered manifest, so the
options were forking the subchart or post-processing YAML outside nelm. Render patches keep that fix
in the chart (or in a CI-supplied patches file), reuse the matcher and jq machinery `diffPatches`
already ships, and stay visible in `nelm chart render` output.

## Verification

- Hand-run against a scratch chart with the built binary, `chart render` in local mode (no cluster):
  chart-shipped `renderPatches` dropped `spec.replicas` and added a label in the rendered output,
  `--no-default-patches` ignored them, a rule from `--patches` applied, and `helm.sh/hook` added by a
  render patch showed up in the manifest.
- Error paths, same setup: identity change (`.metadata.name = "renamed"`), output that is not a
  resource (`.spec`, `.spec.template.spec.containers[]`), `empty`, `., .`, `.metadata.name`, and an
  unparsable jq program — the last fails at resolve time, before any rendered result is used.
- `task test:unit` (full suite) plus `task test:unit tags=ai_tests paths="./pkg/resource/spec"` for
  the new tagged tests.
- Linted with explicit package paths (`golangci-lint run <pkg dirs except helm> ./cmd/...`), 0 issues.
  Worth knowing: on macOS `task lint` silently narrows to `./cmd/...`, because the Taskfile's default
  path expression relies on GNU `find -printf`.
- Review fixes (`StoreAsNone` exemption, metadata string-map check, per-rule matcher re-derivation)
  have no hand-run of their own beyond unit tests. The live-cluster run below is on the PR head
  commit, so it exercises the render path with those fixes in place, but does not target them.
- Live cluster (minikube, Kubernetes 1.34), scratch chart shipping a `renderPatches` rule over a
  ConfigMap: `chart render` applied the rule, `--no-default-patches` ignored it, and a rule from
  `--patches` layered on top of the chart-shipped one. `release install` put the patched `data` in
  the cluster; editing the rule made `release plan install` show the expected `-`/`+` diff and the
  next `release install` performed an `Update`; `release uninstall` removed the resource.
- Context-cancellation fix: covered by the three new tagged unit tests only; no separate hand-run.
- Not run: `release rollback` and the rollback-on-failure path were never exercised against a
  cluster, so that wiring is covered by unit tests only.

## Review focus / risks

- The rename touches every diff-patch call site. `diffPatches` is unreleased (it exists only on `2`,
  in no tag), so there is no user-facing break, but `plan.BuildResourceInfosOptions.DiffPatches`
  changing to `[]*spec.CompiledPatch` is an API change for embedders.
- `namespaces:` matches differently at render time on purpose: there is no live object, so an empty
  namespace is treated as the release namespace and cluster-scoped resources are indistinguishable
  from namespaced ones without an explicit namespace. Combine `namespaces:` with `kinds:` when that
  matters. `pkg/resource/spec/resource_spec.go` carries the reasoning.
- `StoreAs` is re-derived only in the render-patch stage, deliberately: the shared
  `BuildPatchedResourceSpecs` loop is untouched, so `--add-annotation helm.sh/hook=...` still does not
  reclassify a resource while a render patch does.
- Render patches reach the cluster, so the cost of a bad rule is higher than for diff patches. Guarded
  by the identity check, the one-object contract and the metadata string-map check; not guarded
  against value-level mistakes elsewhere in the object, e.g. jq division yields a float and
  `.spec.replicas /= 2` renders `1.5` for the API to reject.
- `chart lint` starts applying diff patches, which changes its dry-run diff results for charts that
  ship `patches.yaml`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



