### PR TITLE
chore(ci): report lint and unit checks on release-please PRs

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   detect-changes:
     name: Detect changed file groups
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.head.ref, 'release-please--') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:
@@ -46,13 +45,13 @@ jobs:
     needs: detect-changes
     uses: ./.github/workflows/_lint.yml
     with:
-      forceSkip: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.lint_changed == 'false' }}
+      forceSkip: ${{ github.event_name == 'pull_request' && (needs.detect-changes.outputs.lint_changed == 'false' || startsWith(github.event.pull_request.head.ref, 'release-please--')) }}
 
   unit:
     needs: detect-changes
     uses: ./.github/workflows/_test_unit.yml
     with:
-      forceSkip: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.src_changed == 'false' }}
+      forceSkip: ${{ github.event_name == 'pull_request' && (needs.detect-changes.outputs.src_changed == 'false' || startsWith(github.event.pull_request.head.ref, 'release-please--')) }}
 
   build:
     needs: detect-changes


### PR DESCRIPTION
Skipping the detect-changes job on release-please branches also skipped the lint and unit caller jobs, so the reusable workflows were never invoked and the "lint / _" and "unit / _" check runs required by the "require pr checks" ruleset were never created. Fold the release-please condition into forceSkip instead: the reusable workflows are called, the inner job is skipped, and the required checks report as skipped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

