### PR TITLE
fix: switch managed-services.deckhouse.io readiness tracking to Available only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/wI2L/jsondiff v0.5.0
 	github.com/werf/common-go v0.0.0-20251113140850-a1a98e909e9b
-	github.com/werf/kubedog v0.13.1-0.20260811104953-26a7ce74643f
+	github.com/werf/kubedog v0.13.1-0.20260826131632-6d8dc9e2e3c5
 	github.com/werf/lockgate v0.1.1
 	github.com/werf/logboek v0.6.1
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ github.com/werf/kubedog v0.13.1-0.20260810124646-25ca603e12eb h1:MBZMwYpj+SFTkiZ
 github.com/werf/kubedog v0.13.1-0.20260810124646-25ca603e12eb/go.mod h1:+pTZuZqy+xtj6yh49kfQuBGDMHdm7zVJbVl2s4xawe8=
 github.com/werf/kubedog v0.13.1-0.20260811104953-26a7ce74643f h1:EBXXN/v3/zzRrHxu8Nu96XDU2zd2Oc5rSLIXCIhv1gg=
 github.com/werf/kubedog v0.13.1-0.20260811104953-26a7ce74643f/go.mod h1:+pTZuZqy+xtj6yh49kfQuBGDMHdm7zVJbVl2s4xawe8=
+github.com/werf/kubedog v0.13.1-0.20260826131632-6d8dc9e2e3c5 h1:vPRcvySNVpkkBKew7XlGPA6QTle3BcU27R3S9nClW8c=
+github.com/werf/kubedog v0.13.1-0.20260826131632-6d8dc9e2e3c5/go.mod h1:+pTZuZqy+xtj6yh49kfQuBGDMHdm7zVJbVl2s4xawe8=
 github.com/werf/lockgate v0.1.1 h1:S400JFYjtWfE4i4LY9FA8zx0fMdfui9DPrBiTciCrx4=
 github.com/werf/lockgate v0.1.1/go.mod h1:0yIFSLq9ausy6ejNxF5uUBf/Ib6daMAfXuCaTMZJzIE=
 github.com/werf/logboek v0.6.1 h1:oEe6FkmlKg0z0n80oZjLplj6sXcBeLleCkjfOOZEL2g=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

