### PR TITLE
fix(plan): purge previous-release resources after install

### DIFF
--- a/ISSUE_purge_after_install.md
+++ b/ISSUE_purge_after_install.md
@@ -1,0 +1,72 @@
+# Issue draft for werf/nelm (copy into GitHub)
+
+**Title:** Upgrade deadlocks when purged PVCs are deleted before Deployment update (`pre-pre-uninstall` + `TrackAbsence`)
+
+## Summary
+
+On `nelm release install` / upgrade, resources removed from the chart (purged from the previous release) are scheduled in stage `pre-pre-uninstall`, **before** `install`. For each deleted object Nelm always runs `Delete` and then `TrackAbsence` (`MustTrackAbsence: true`).
+
+That ordering differs from Helm 3 and causes a hard deadlock for `PersistentVolumeClaim`s protected by `kubernetes.io/pvc-protection` while a Pod from the **old** Deployment still mounts them.
+
+## Helm 3 behavior (works)
+
+In Helm 3 `kube.Client.Update`:
+
+1. Create/update resources from the new release (including a new PVC and Deployment roll).
+2. Delete objects that are no longer in the chart.
+3. `--wait` waits for **readiness** of the new release resources, not for every purged PVC to become fully absent.
+
+Workloads move off the old claim first; then the PVC can finish deletion.
+
+## Nelm behavior (deadlocks)
+
+Relevant code (before fix):
+
+- `pkg/plan/resource_info.go` → `buildDeletableResourceInfo`: for non-uninstall deploy types, `stage = StagePrePreUninstall`.
+- `pkg/common/common.go` → `StagesOrdered`: `pre-pre-uninstall` runs **before** `install`.
+- `pkg/plan/plan_build.go` → `addDeleteResourcesOps`: `Delete` chained with `TrackAbsence`.
+- `MustTrackAbsence` is always `true` when `MustDelete` is true.
+
+Observed progress during a hang:
+
+```text
+RESOURCE (→ABSENT)   PersistentVolumeClaim/...  WAITING
+RESOURCE (→ABSENT)   PersistentVolume/...       WAITING
+Secret/...           ABSENT
+StorageClass/...     ABSENT
+```
+
+Deployment/pods stay on the old PVC; install stage never starts. Cancel + retry often “works” because the pending revision / orphaned inventory changes and the second plan no longer blocks on the same deletes before install.
+
+## Reproduction (minimal)
+
+1. Release with a Deployment mounting a PVC (static SMB PV + `Retain` is a strong case).
+2. Upgrade so the PVC name changes (e.g. volume id suffix changes) → plan: create new PVC/PV, update Deployment claimName, delete old PVC/PV.
+3. Run `nelm release install` with readiness tracking enabled.
+4. Observe hang on `→ABSENT` for the old PVC/PV while Deployment is still unchanged.
+
+## Expected
+
+Closer to Helm: **install/update first**, then purge previous-release resources (and only then wait for absence, if at all). After the Deployment rolls to the new claim, `pvc-protection` can clear and the old PVC can disappear.
+
+## Proposed fix
+
+Schedule purged deletable resources on **`StageUninstall`** (after `StageInstall`) for upgrade/install/rollback as well as uninstall, instead of `StagePrePreUninstall`.
+
+PoC branch: `fix/purge-resources-after-install` (fork).
+
+Optional follow-ups:
+
+- Make `MustTrackAbsence` configurable / skip for PV+PVC with `Retain`.
+- Document the stage order vs Helm for resource replacement.
+
+## Environment
+
+- Nelm 1.29.x / 1.30.x
+- Charts that replace PVC identity across upgrades (e.g. generated volume id)
+- CSI / SMB volumes with PVC protection finalizers
+
+## Related
+
+- https://github.com/werf/nelm/issues/99 (hang involving PVC on dismiss)
+- `werf.io/track-termination-mode: NonBlocking` does **not** help: it only affects readiness tracking, not `TrackAbsence`

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -72,12 +72,12 @@ const (
 	ResourceStateReady   ResourceState = "ready"
 
 	StageInit              Stage = "init"                // create pending release
-	StagePrePreUninstall   Stage = "pre-pre-uninstall"   // uninstall previous release resources
+	StagePrePreUninstall   Stage = "pre-pre-uninstall"   // legacy early uninstall stage (kept for plan compatibility)
 	StagePrePreInstall     Stage = "pre-pre-install"     // install crd
 	StagePreInstall        Stage = "pre-install"         // install pre-hooks
 	StagePreUninstall      Stage = "pre-uninstall"       // cleanup pre-hooks
 	StageInstall           Stage = "install"             // install resources
-	StageUninstall         Stage = "uninstall"           // cleanup resources
+	StageUninstall         Stage = "uninstall"           // cleanup resources, including purged previous-release resources (after install)
 	StagePostInstall       Stage = "post-install"        // install post-hooks
 	StagePostUninstall     Stage = "post-uninstall"      // cleanup post-hooks
 	StagePostPostInstall   Stage = "post-post-install"   // install webhook

--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -342,12 +342,11 @@ func fixManagedFields(ctx context.Context, unstruct *unstructured.Unstructured, 
 }
 
 func buildDeletableResourceInfo(ctx context.Context, localRes *resource.DeletableResource, deployType common.DeployType, releaseName, releaseNamespace string, clientFactory kube.ClientFactorier) (*DeletableResourceInfo, error) {
-	var stage common.Stage
-	if deployType == common.DeployTypeUninstall {
-		stage = common.StageUninstall
-	} else {
-		stage = common.StagePrePreUninstall
-	}
+	// Purge previous-release resources in StageUninstall, which runs after
+	// StageInstall. Helm updates/creates first and only then deletes removed
+	// objects; waiting for ABSENT in pre-pre-uninstall before install deadlocks
+	// PVCs still mounted by pods that are updated only during install.
+	stage := deletableResourceStage(deployType)
 
 	noDeleteInfo := &DeletableResourceInfo{
 		ResourceMeta:  localRes.ResourceMeta,
@@ -394,6 +393,18 @@ func buildDeletableResourceInfo(ctx context.Context, localRes *resource.Deletabl
 		MustTrackAbsence: true,
 		Stage:            stage,
 	}, nil
+}
+
+// deletableResourceStage places purge/delete of release resources after install.
+// Previously non-uninstall deploys used StagePrePreUninstall, which blocked the
+// install stage on TrackAbsence (e.g. PVC finalizers) before Deployment updates.
+func deletableResourceStage(deployType common.DeployType) common.Stage {
+	switch deployType {
+	case common.DeployTypeInitial, common.DeployTypeInstall, common.DeployTypeUpgrade, common.DeployTypeRollback, common.DeployTypeUninstall:
+		return common.StageUninstall
+	default:
+		return common.StageUninstall
+	}
 }
 
 func isServiceAccountManagedFieldFixRequired(localRes *unstructured.Unstructured, entry *v1.ManagedFieldsEntry) (bool, error) {

--- a/pkg/plan/resource_info_test.go
+++ b/pkg/plan/resource_info_test.go
@@ -178,15 +178,29 @@ func (s *ResourceInfoSuite) TestBuildDeletableResourceInfo() {
 		},
 		{
 			expect: func(localRes *resource.DeletableResource) *plan.DeletableResourceInfo {
-				info := defaultDeletableResourceInfo(localRes, s.releaseName, s.releaseNamespace)
-				info.Stage = common.StagePrePreUninstall
-
-				return info
+				// Upgrade/install purge runs in StageUninstall (after StageInstall),
+				// same as full uninstall — so workloads can move off old PVCs first.
+				return defaultDeletableResourceInfo(localRes, s.releaseName, s.releaseNamespace)
 			},
 			input: func() (*resource.DeletableResource, common.DeployType) {
 				return defaultDeletableResource(s.releaseName, s.releaseNamespace), common.DeployTypeInstall
 			},
-			name: `for existing resource, initial deploy`,
+			name: `for existing resource, install deploy purges after install stage`,
+			prepare: func() {
+				_, err := s.clientFactory.KubeClient().Create(context.Background(), defaultResourceSpec(s.releaseName, s.releaseNamespace), kube.KubeClientCreateOptions{
+					DefaultNamespace: s.releaseNamespace,
+				})
+				s.Require().NoError(err)
+			},
+		},
+		{
+			expect: func(localRes *resource.DeletableResource) *plan.DeletableResourceInfo {
+				return defaultDeletableResourceInfo(localRes, s.releaseName, s.releaseNamespace)
+			},
+			input: func() (*resource.DeletableResource, common.DeployType) {
+				return defaultDeletableResource(s.releaseName, s.releaseNamespace), common.DeployTypeUpgrade
+			},
+			name: `for existing resource, upgrade deploy purges after install stage`,
 			prepare: func() {
 				_, err := s.clientFactory.KubeClient().Create(context.Background(), defaultResourceSpec(s.releaseName, s.releaseNamespace), kube.KubeClientCreateOptions{
 					DefaultNamespace: s.releaseNamespace,


### PR DESCRIPTION
Schedule deletable resources on StageUninstall instead of StagePrePreUninstall so create/update (and Deployment rolls) run before Delete+TrackAbsence. Avoids PVC pvc-protection deadlocks when volume identity changes on upgrade (Helm-like order).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

