### PR TITLE
fix: skippable untouched resources check for progress reporter

### DIFF
--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -190,10 +190,11 @@ func runFailurePlan(ctx context.Context, releaseNamespace string, failedPlan *pl
 	log.Default.Debug(ctx, "Execute failure plan")
 
 	if err := plan.ExecutePlan(ctx, releaseNamespace, failurePlan, taskStore, logStore, informerFactory, history, clientFactory, plan.ExecutePlanOptions{
-		LegacyProgressReporter:   opts.LegacyProgressReporter,
-		TrackingOptions:          opts.TrackingOptions,
-		NetworkParallelism:       opts.NetworkParallelism,
-		InstallableResourceInfos: installableInfos,
+		LegacyProgressReporter:     opts.LegacyProgressReporter,
+		TrackingOptions:            opts.TrackingOptions,
+		NetworkParallelism:         opts.NetworkParallelism,
+		InstallableResourceInfos:   installableInfos,
+		NoUntouchedResourcesReport: true,
 	}); err != nil {
 		critErrs.Add(fmt.Errorf("execute failure plan: %w", err))
 	}

--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -193,7 +193,6 @@ func runFailurePlan(ctx context.Context, releaseNamespace string, failedPlan *pl
 		LegacyProgressReporter:     opts.LegacyProgressReporter,
 		TrackingOptions:            opts.TrackingOptions,
 		NetworkParallelism:         opts.NetworkParallelism,
-		InstallableResourceInfos:   installableInfos,
 		NoUntouchedResourcesReport: true,
 	}); err != nil {
 		critErrs.Add(fmt.Errorf("execute failure plan: %w", err))

--- a/pkg/action/release_install.go
+++ b/pkg/action/release_install.go
@@ -545,7 +545,7 @@ func releaseInstall(ctx context.Context, ctxCancelFn context.CancelCauseFunc, re
 			reporter := plan.NewLegacyProgressReporter(opts.LegacyProgressReportCh)
 			defer close(opts.LegacyProgressReportCh)
 
-			reporter.StartStage(installPlan, releaseNamespace, instResInfos, clientFactory.Mapper())
+			reporter.StartStage(installPlan, releaseNamespace, instResInfos, clientFactory.Mapper(), plan.StartStageOptions{})
 			reporter.Stop(ctx)
 		}
 
@@ -975,7 +975,7 @@ func runRollbackPlan(ctx context.Context, releaseName, releaseNamespace string, 
 
 	if releaseIsUpToDate && planIsUseless {
 		if opts.LegacyProgressReporter != nil {
-			opts.LegacyProgressReporter.StartStage(rollbackPlan, releaseNamespace, instResInfos, clientFactory.Mapper())
+			opts.LegacyProgressReporter.StartStage(rollbackPlan, releaseNamespace, instResInfos, clientFactory.Mapper(), plan.StartStageOptions{})
 		}
 
 		log.Default.Info(ctx, color.Style{color.Bold, color.Green}.Render("Skipped rollback release")+" %q (namespace: %q): cluster resources already as desired", releaseName, releaseNamespace)

--- a/pkg/legacy/progrep/progress_report.go
+++ b/pkg/legacy/progrep/progress_report.go
@@ -29,9 +29,12 @@ type ProgressReport struct {
 	StageReports []StageReport `json:"stageReports"`
 }
 
-// StageReport contains ALL operations in the plan, plus untouched resources reported as
-// NoOp with status Completed -- from the very first report, every operation is present
-// (initially as Pending).
+// StageReport contains ALL operations in the plan -- from the very first report, every
+// operation is present (initially as Pending). A stage of a plan that describes a complete
+// desired state, such as an install or a rollback plan, additionally lists the resources that
+// plan leaves untouched, as NoOp with status Completed. Each stage computes that set from its
+// own plan. A failure plan acts upon a few resources only, so its stage lists just its own
+// operations.
 type StageReport struct {
 	Operations []Operation `json:"operations"`
 }

--- a/pkg/legacy/progrep/progress_report.go
+++ b/pkg/legacy/progrep/progress_report.go
@@ -32,9 +32,9 @@ type ProgressReport struct {
 // StageReport contains ALL operations in the plan -- from the very first report, every
 // operation is present (initially as Pending). A stage of a plan that describes a complete
 // desired state, such as an install or a rollback plan, additionally lists the resources that
-// plan leaves untouched, as NoOp with status Completed. Each stage computes that set from its
-// own plan. A failure plan acts upon a few resources only, so its stage lists just its own
-// operations.
+// plan leaves untouched, as NoOp with status Completed; that set is supplied per stage and
+// matches the revision the stage deploys. A failure plan acts upon a few resources only, so
+// its stage lists just its own operations.
 type StageReport struct {
 	Operations []Operation `json:"operations"`
 }

--- a/pkg/plan/legacy_progress_reporter.go
+++ b/pkg/plan/legacy_progress_reporter.go
@@ -43,8 +43,14 @@ func (r *LegacyProgressReporter) ReportStatus(opID string, status progrep.Operat
 	})
 }
 
-func (r *LegacyProgressReporter) StartStage(p *Plan, releaseNamespace string, installableResourceInfos []*InstallableResourceInfo, mapper meta.RESTMapper) {
+func (r *LegacyProgressReporter) StartStage(p *Plan, releaseNamespace string, installableResourceInfos []*InstallableResourceInfo, mapper meta.RESTMapper, opts StartStageOptions) {
 	resolvedNamespaces := buildResolvedNamespaces(p, releaseNamespace, mapper)
+
+	if opts.NoUntouchedResources {
+		r.startStage(p, resolvedNamespaces, nil, nil)
+
+		return
+	}
 
 	untouchedResolvedNamespaces := make(map[string]string, len(installableResourceInfos))
 	for _, info := range installableResourceInfos {
@@ -153,6 +159,15 @@ func (r *LegacyProgressReporter) startStage(p *Plan, resolvedNamespaces map[stri
 		report := buildProgressReport(s.frozen, s.ops)
 		sendNonBlocking(r.reportCh, report)
 	})
+}
+
+// StartStageOptions configures StartStage.
+type StartStageOptions struct {
+	// NoUntouchedResources, when true, omits untouched resources from the stage report.
+	// Set it for delta plans, like a failure plan, which only carry operations for the few
+	// resources they act upon: there the release-wide inventory of untouched resources is
+	// not part of what the stage does.
+	NoUntouchedResources bool
 }
 
 type progressReporterState struct {

--- a/pkg/plan/legacy_progress_reporter.go
+++ b/pkg/plan/legacy_progress_reporter.go
@@ -161,7 +161,6 @@ func (r *LegacyProgressReporter) startStage(p *Plan, resolvedNamespaces map[stri
 	})
 }
 
-// StartStageOptions configures StartStage.
 type StartStageOptions struct {
 	// NoUntouchedResources, when true, omits untouched resources from the stage report.
 	// Set it for delta plans, like a failure plan, which only carry operations for the few

--- a/pkg/plan/legacy_progress_reporter_ai_test.go
+++ b/pkg/plan/legacy_progress_reporter_ai_test.go
@@ -569,6 +569,52 @@ func TestAI_StartStage_FreezesPreviousStage(t *testing.T) {
 	assert.Equal(t, progrep.OperationStatusPending, activeOps[0].Status)
 }
 
+func TestAI_StartStage_NoUntouchedResourcesOmitsBackfill(t *testing.T) {
+	mapper := newFakeRESTMapper()
+	releaseNS := "release-ns"
+
+	op := &Operation{
+		Type: OperationTypeDelete, Version: OperationVersionDelete, Category: OperationCategoryResource,
+		Config: &OperationConfigDelete{ResourceMeta: makeResourceMeta("job1", releaseNS, gvkConfigMap)},
+	}
+	p := buildTestPlan([]*Operation{op}, nil)
+
+	untouched := []*InstallableResourceInfo{
+		makeUntouchedInfo("cm1", releaseNS, gvkConfigMap),
+		makeUntouchedInfo("cm2", releaseNS, gvkConfigMap),
+	}
+
+	t.Run("included by default", func(t *testing.T) {
+		ch := make(chan progrep.ProgressReport, 64)
+		reporter := NewLegacyProgressReporter(ch)
+
+		reporter.StartStage(p, releaseNS, untouched, mapper, StartStageOptions{})
+
+		reports := drainChannel(ch)
+		require.NotEmpty(t, reports)
+
+		ops := reports[len(reports)-1].StageReports[0].Operations
+		assert.Len(t, ops, 3, "plan op plus both untouched resources")
+	})
+
+	t.Run("omitted when NoUntouchedResources", func(t *testing.T) {
+		ch := make(chan progrep.ProgressReport, 64)
+		reporter := NewLegacyProgressReporter(ch)
+
+		reporter.StartStage(p, releaseNS, untouched, mapper, StartStageOptions{
+			NoUntouchedResources: true,
+		})
+
+		reports := drainChannel(ch)
+		require.NotEmpty(t, reports)
+
+		ops := reports[len(reports)-1].StageReports[0].Operations
+		require.Len(t, ops, 1, "only the plan's own operation")
+		assert.Equal(t, "job1", ops[0].Name)
+		assert.Equal(t, progrep.OperationTypeDelete, ops[0].Type)
+	})
+}
+
 func TestAI_StartStage_ReportStatusNeverAffectsUntouchedEntry(t *testing.T) {
 	ch := make(chan progrep.ProgressReport, 64)
 	reporter := NewLegacyProgressReporter(ch)

--- a/pkg/plan/plan_execute.go
+++ b/pkg/plan/plan_execute.go
@@ -29,6 +29,9 @@ type ExecutePlanOptions struct {
 	InstallableResourceInfos []*InstallableResourceInfo
 	LegacyProgressReporter   *LegacyProgressReporter
 	NetworkParallelism       int
+	// NoUntouchedResourcesReport, when true, omits untouched resources from the progress
+	// report for this plan. Set it for delta plans, like a failure plan.
+	NoUntouchedResourcesReport bool
 }
 
 // Executes the given plan. It doesn't care what kind of plan it is (install, upgrade, failure plan,
@@ -42,7 +45,9 @@ func ExecutePlan(parentCtx context.Context, releaseNamespace string, plan *Plan,
 	opts.NetworkParallelism = lo.Max([]int{opts.NetworkParallelism, 1})
 
 	if opts.LegacyProgressReporter != nil {
-		opts.LegacyProgressReporter.StartStage(plan, releaseNamespace, opts.InstallableResourceInfos, clientFactory.Mapper())
+		opts.LegacyProgressReporter.StartStage(plan, releaseNamespace, opts.InstallableResourceInfos, clientFactory.Mapper(), StartStageOptions{
+			NoUntouchedResources: opts.NoUntouchedResourcesReport,
+		})
 	}
 
 	workerPool := pool.New().WithContext(ctx).WithMaxGoroutines(opts.NetworkParallelism).WithCancelOnError().WithFirstError()


### PR DESCRIPTION
## Summary

`LegacyProgressReporter` lost resources from its report after a failed deploy. When a resource
failed (e.g. a CronJob whose name exceeds the 52-char limit), nelm runs a failure plan through
`ExecutePlan`, which opens a new reporter stage. That stage was backfilled with the release-wide
inventory of untouched resources, so it degenerated into ~337 `NoOp`/`Completed` entries: resources
that were never created disappeared, and a resource whose update genuinely failed came back as
`NoOp`/`Completed`.

## Key changes

- Add `StartStageOptions{NoUntouchedResources}` to `StartStage`; when set, the stage carries only
  the plan's own operations.
- Plumb it through `ExecutePlanOptions.NoUntouchedResourcesReport`.
- Set it in `runFailurePlan` only — the single entry point for failure plans across install,
  rollback and uninstall. Full desired-state plans (install, rollback) keep the backfill.
- Document on `StageReport` when a stage lists untouched resources and when it does not, and that
  each stage derives that set from its own plan.

## Why

The backfill answers "what is the state of the release" and is correct for a plan that describes
the desired state in full. A failure plan is a delta acting upon a few resources; there the
inventory does not complete the picture, it replaces it — including overwriting real failures.

## Verification

- Reproduced the reported scenario with a throwaway harness (not committed): a 400-resource plan
  (337 pre-existing, 63 new) built through the real `BuildPlan`/`BuildFailurePlan` against a fake
  cluster. Before: stage 1 held 337 `NoOp`/`Completed` entries. After: stage 0 keeps all 400 ops
  with the single real failure, stage 1 is empty.
- Not exercised against a live cluster — none was available.

## Review focus / risks

- `StartStage` is public and its signature changed; external callers need the extra argument.
- The `StageReport` docstring now states when untouched resources appear. The stage contract itself
  is untouched and still needs a separate rework: stages carry no type, so a consumer cannot tell a
  failure stage from a deploy stage.
