### PR TITLE
feat: support authenticated secret values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/sjson v1.2.5
 	github.com/wI2L/jsondiff v0.7.0
-	github.com/werf/common-go v0.0.0-20260428201303-b0dcadceca5c
+	github.com/werf/common-go v0.0.0-20260831162604-46c3b45163be
 	github.com/werf/kubedog v0.13.1-0.20260807153813-e8f61a4bc90a
 	github.com/werf/lockgate v0.1.1
 	github.com/werf/logboek v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324 h1:aqEM5aboMpBfsILja
 github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/werf/common-go v0.0.0-20260428201303-b0dcadceca5c h1:4/qKB2licflIlCZGX4U1o4Ij/oraYyuNc2cWFiutZ10=
 github.com/werf/common-go v0.0.0-20260428201303-b0dcadceca5c/go.mod h1:DlN/hD9tXLxYgdAMkulQdzHkiaPrvs3MzgPZvjluea4=
+github.com/werf/common-go v0.0.0-20260831162604-46c3b45163be h1:r5zI64fcwZJfELi/uGgLV2YWOWx1QY9YW1yVkRba2do=
+github.com/werf/common-go v0.0.0-20260831162604-46c3b45163be/go.mod h1:DlN/hD9tXLxYgdAMkulQdzHkiaPrvs3MzgPZvjluea4=
 github.com/werf/kubedog v0.13.1-0.20260807153813-e8f61a4bc90a h1:O3LWkGBPLb9P3jUdvRIpASe+m65iMtsKSI1joJIR3B4=
 github.com/werf/kubedog v0.13.1-0.20260807153813-e8f61a4bc90a/go.mod h1:5s5JQyn7rI+63ppk5MGPBYv6uRv0HARLD3kLN8FEFsw=
 github.com/werf/lockgate v0.1.1 h1:S400JFYjtWfE4i4LY9FA8zx0fMdfui9DPrBiTciCrx4=


### PR DESCRIPTION
## Summary

Nelm v2 now uses common-go branch `1`, adding authenticated AES-GCM secret encryption while retaining read support for existing AES-CBC secrets. It can read and write the format required by the werf v3 rollout.

Related: https://github.com/werf/nelm/issues/677

## What

### Breaking

- BREAKING: secrets written by nelm v2 use AES-GCM formats that cannot be read by earlier nelm or werf releases. Upgrade every CI job and saved deploy-plan consumer before re-encrypting a repository.
- Existing AES-CBC encrypted values remain readable, but new writes use authenticated formats.

### Secret values

- Whole-blob secrets use version 2 and YAML scalar secrets use version 3, preventing whole-blob values from being interpreted as scalar metadata.
- YAML scalar tags, block styles, and value comments survive a secret-values edit cycle. Existing values that lost their original type remain strings until re-entered.
- Whole-blob ciphertext can be used as a scalar in an additional secret-values file without frame corruption.

## Why

The previous common-go AES-CBC format accepted tampered data and wrong keys without reliable detection, while secret YAML encryption discarded scalar metadata. Nelm needs the common-go v1 implementation so its v2 release participates in the coordinated authenticated-secret rollout with werf v3.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

