### PR TITLE
chore: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security
+
+## Reporting a vulnerability
+
+If you find a security related bug, we kindly ask you for responsible
+disclosure and for giving us appropriate time to react, analyze and develop a
+fix to mitigate the found security vulnerability.
+
+Please report vulnerabilities by e-mail to the following address:
+
+* cncf-werf-security@lists.cncf.io
+
+All vulnerabilities and associated information will be treated with full confidentiality.
+
+## Public disclosure
+
+Security vulnerabilities will be disclosed via release notes, and will
+credit you for your findings (unless you prefer to stay anonymous, of course).


### PR DESCRIPTION
## Summary

nelm now publishes project-level guidance for responsibly reporting security vulnerabilities and explains how accepted vulnerabilities are publicly disclosed.

## What

- Security reports are directed to `cncf-werf-security@lists.cncf.io`.
- Vulnerability details are treated confidentially.
- Public disclosure happens through release notes and credits reporters unless they prefer anonymity.

## Why

The repository previously had no security policy, leaving reporters without a documented disclosure channel or expectations for handling and publication.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

