### PR TITLE
fix: restore network parallelism when building resource infos

### DIFF
--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -90,7 +90,7 @@ type BuildResourceInfosOptions struct {
 func BuildResourceInfos(ctx context.Context, deployType common.DeployType, releaseName, releaseNamespace string, instResources []*resource.InstallableResource, delResources []*resource.DeletableResource, prevReleaseFailed bool, clientFactory kube.ClientFactorier, opts BuildResourceInfosOptions) (instResourceInfos []*InstallableResourceInfo, delResourceInfos []*DeletableResourceInfo, err error) {
 	totalResourcesCount := len(instResources) + len(delResources)
 
-	routines := lo.Max([]int{len(instResources) / lo.Max([]int{totalResourcesCount, 1}) * opts.NetworkParallelism, 1})
+	routines := poolRoutines(len(instResources), totalResourcesCount, opts.NetworkParallelism)
 
 	instResourcesPool := pool.NewWithResults[[]*InstallableResourceInfo]().WithContext(ctx).WithMaxGoroutines(routines).WithCancelOnError().WithFirstError()
 	for _, res := range instResources {
@@ -104,7 +104,7 @@ func BuildResourceInfos(ctx context.Context, deployType common.DeployType, relea
 		})
 	}
 
-	routines = lo.Max([]int{len(delResources) / lo.Max([]int{totalResourcesCount, 1}) * opts.NetworkParallelism, 1})
+	routines = poolRoutines(len(delResources), totalResourcesCount, opts.NetworkParallelism)
 
 	delResourcesPool := pool.NewWithResults[*DeletableResourceInfo]().WithContext(ctx).WithMaxGoroutines(routines).WithCancelOnError().WithFirstError()
 	for _, res := range delResources {
@@ -799,6 +799,10 @@ func orphaned(meta *spec.ResourceMeta, releaseName, releaseNamespace string) boo
 	}
 
 	return false
+}
+
+func poolRoutines(resourcesCount, totalResourcesCount, networkParallelism int) int {
+	return lo.Max([]int{resourcesCount * networkParallelism / lo.Max([]int{totalResourcesCount, 1}), 1})
 }
 
 func removeUndesirableManagers(managedFields []v1.ManagedFieldsEntry, oursEntry v1.ManagedFieldsEntry, noRemoveManualChanges bool) (newManagedFields []v1.ManagedFieldsEntry, newOursEntry v1.ManagedFieldsEntry, changed bool) {

--- a/pkg/plan/resource_info_ai_test.go
+++ b/pkg/plan/resource_info_ai_test.go
@@ -41,6 +41,29 @@ func TestAI_ExclusiveOwnershipForOurManagerDeckhouseControllerGateEnabled(t *tes
 	assert.False(t, hasManager(newManagedFields, common.OldDeckhouseControllerManager))
 }
 
+func TestAI_PoolRoutines(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		resourcesCount     int
+		totalCount         int
+		networkParallelism int
+		expected           int
+	}{
+		{name: "all resources installable", resourcesCount: 100, totalCount: 100, networkParallelism: 30, expected: 30},
+		{name: "mostly installable", resourcesCount: 100, totalCount: 105, networkParallelism: 30, expected: 28},
+		{name: "even split", resourcesCount: 50, totalCount: 100, networkParallelism: 30, expected: 15},
+		{name: "single resource of each kind", resourcesCount: 1, totalCount: 2, networkParallelism: 30, expected: 15},
+		{name: "small share never drops below one", resourcesCount: 5, totalCount: 105, networkParallelism: 30, expected: 1},
+		{name: "no resources", resourcesCount: 0, totalCount: 0, networkParallelism: 30, expected: 1},
+		{name: "minimal parallelism", resourcesCount: 1, totalCount: 2, networkParallelism: 1, expected: 1},
+		{name: "zero parallelism still yields a usable pool", resourcesCount: 1, totalCount: 2, networkParallelism: 0, expected: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, poolRoutines(tt.resourcesCount, tt.totalCount, tt.networkParallelism))
+		})
+	}
+}
+
 func TestAI_RemoveUndesirableManagersDeckhouseControllerGateDisabled(t *testing.T) {
 	featgate.FeatGateAdoptDeckhouseControllerFields.Disable()
 	t.Cleanup(featgate.FeatGateAdoptDeckhouseControllerFields.Disable)


### PR DESCRIPTION
Integer division truncated to zero before multiplication, collapsing both resource pools to a single goroutine whenever a release had both installable and deletable resources.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/werf/nelm/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

