### PR TITLE
fix: optimize plan building for large releases

### DIFF
--- a/pkg/plan/helpers_ai_test.go
+++ b/pkg/plan/helpers_ai_test.go
@@ -4,9 +4,14 @@ package plan
 
 import (
 	"fmt"
+	"math/rand"
 
+	"github.com/dominikbraun/graph"
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/werf/nelm/pkg/legacy/progrep"
 	"github.com/werf/nelm/pkg/resource/spec"
@@ -46,6 +51,14 @@ func (m *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 	}
 
 	return nil, fmt.Errorf("no mapping for %v", gk)
+}
+
+func deletableInfoWithUID(uid types.UID) *DeletableResourceInfo {
+	return &DeletableResourceInfo{GetResult: unstructuredWithUID(uid)}
+}
+
+func installableInfoWithUID(uid types.UID) *InstallableResourceInfo {
+	return &InstallableResourceInfo{GetResult: unstructuredWithUID(uid)}
 }
 
 func makeResourceSpec(name, namespace string, gvk schema.GroupVersionKind) *spec.ResourceSpec {
@@ -95,4 +108,69 @@ func makeResourceMeta(name, namespace string, gvk schema.GroupVersionKind) *spec
 		Namespace:        namespace,
 		GroupVersionKind: gvk,
 	}
+}
+
+func randomTrackingGraph(rnd *rand.Rand, opsCount int, edgeChance float64) ([]OperationCategory, map[int][]int) {
+	allCategories := []OperationCategory{OperationCategoryResource, OperationCategoryTrack, OperationCategoryMeta}
+
+	categories := make([]OperationCategory, opsCount)
+	for i := range categories {
+		categories[i] = allCategories[rnd.Intn(len(allCategories))]
+	}
+
+	deps := map[int][]int{}
+	for from := 0; from < opsCount; from++ {
+		for to := from + 1; to < opsCount; to++ {
+			if rnd.Float64() < edgeChance {
+				deps[to] = append(deps[to], from)
+			}
+		}
+	}
+
+	return categories, deps
+}
+
+// Pre-optimization implementation of squashFinalTrackingOperations, kept as a reference to assert
+// the optimized one against.
+func squashFinalTrackingOperationsReference(p *Plan) {
+	ops := p.Operations()
+	trackingOps := lo.Filter(ops, func(op *Operation, _ int) bool {
+		return op.Category == OperationCategoryTrack
+	})
+
+	for _, trackingOp := range trackingOps {
+		var foundDependentResourceOps bool
+		lo.Must0(graph.BFS(p.Graph, trackingOp.ID(), func(opID string) bool {
+			op := lo.Must(p.Operation(opID))
+			if op.Category == OperationCategoryResource {
+				foundDependentResourceOps = true
+
+				return true
+			}
+
+			return false
+		}))
+
+		if !foundDependentResourceOps {
+			p.SquashOperation(trackingOp)
+		}
+	}
+}
+
+func trackingTestOperations(categories []OperationCategory) []*Operation {
+	return lo.Map(categories, func(category OperationCategory, i int) *Operation {
+		return &Operation{
+			Type:     OperationTypeNoop,
+			Version:  OperationVersionNoop,
+			Category: category,
+			Config:   &OperationConfigNoop{OpID: fmt.Sprintf("op-%d", i)},
+		}
+	})
+}
+
+func unstructuredWithUID(uid types.UID) *unstructured.Unstructured {
+	unstruct := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	unstruct.SetUID(uid)
+
+	return unstruct
 }

--- a/pkg/plan/helpers_ai_test.go
+++ b/pkg/plan/helpers_ai_test.go
@@ -13,7 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/werf/nelm/pkg/common"
 	"github.com/werf/nelm/pkg/legacy/progrep"
+	"github.com/werf/nelm/pkg/resource"
 	"github.com/werf/nelm/pkg/resource/spec"
 )
 
@@ -55,6 +57,21 @@ func (m *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 
 func deletableInfoWithUID(uid types.UID) *DeletableResourceInfo {
 	return &DeletableResourceInfo{GetResult: unstructuredWithUID(uid)}
+}
+
+func installableInfoNamed(name string, installType ResourceInstallType, policies ...common.ResourcePolicy) *InstallableResourceInfo {
+	return &InstallableResourceInfo{
+		ResourceMeta:  makeResourceMeta(name, "test-namespace", gvkConfigMap),
+		LocalResource: &resource.InstallableResource{ResourcePolicies: policies},
+		MustInstall:   installType,
+	}
+}
+
+func installableInfoToDeleteOnSuccessfulInstall(name string) *InstallableResourceInfo {
+	info := installableInfoNamed(name, ResourceInstallTypeApply)
+	info.MustDeleteOnSuccessfulInstall = true
+
+	return info
 }
 
 func installableInfoWithUID(uid types.UID) *InstallableResourceInfo {

--- a/pkg/plan/helpers_ai_test.go
+++ b/pkg/plan/helpers_ai_test.go
@@ -55,6 +55,20 @@ func (m *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 	return nil, fmt.Errorf("no mapping for %v", gk)
 }
 
+func installableInfoToDeleteOnAnyOutcome(name string) *InstallableResourceInfo {
+	info := installableInfoToDeleteOnSuccessfulInstall(name)
+	info.MustDeleteOnFailedInstall = true
+
+	return info
+}
+
+func installableInfoToDeleteOnFailedInstall(name string) *InstallableResourceInfo {
+	info := installableInfoNamed(name, ResourceInstallTypeApply)
+	info.MustDeleteOnFailedInstall = true
+
+	return info
+}
+
 func installableInfoToDeleteOnSuccessfulInstall(name string) *InstallableResourceInfo {
 	info := installableInfoNamed(name, ResourceInstallTypeApply)
 	info.MustDeleteOnSuccessfulInstall = true

--- a/pkg/plan/helpers_ai_test.go
+++ b/pkg/plan/helpers_ai_test.go
@@ -55,6 +55,13 @@ func (m *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 	return nil, fmt.Errorf("no mapping for %v", gk)
 }
 
+func installableInfoToDeleteOnSuccessfulInstall(name string) *InstallableResourceInfo {
+	info := installableInfoNamed(name, ResourceInstallTypeApply)
+	info.MustDeleteOnSuccessfulInstall = true
+
+	return info
+}
+
 func deletableInfoWithUID(uid types.UID) *DeletableResourceInfo {
 	return &DeletableResourceInfo{GetResult: unstructuredWithUID(uid)}
 }
@@ -65,13 +72,6 @@ func installableInfoNamed(name string, installType ResourceInstallType, policies
 		LocalResource: &resource.InstallableResource{ResourcePolicies: policies},
 		MustInstall:   installType,
 	}
-}
-
-func installableInfoToDeleteOnSuccessfulInstall(name string) *InstallableResourceInfo {
-	info := installableInfoNamed(name, ResourceInstallTypeApply)
-	info.MustDeleteOnSuccessfulInstall = true
-
-	return info
 }
 
 func installableInfoWithUID(uid types.UID) *InstallableResourceInfo {

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -272,6 +272,28 @@ func (b *planChainBuilder) Stage(stage common.Stage) *planChainBuilder {
 	return b
 }
 
+func squashFinalTrackingOperations(p *Plan) {
+	adjMap := lo.Must(p.Graph.AdjacencyMap())
+	predMap := lo.Must(p.Graph.PredecessorMap())
+
+	// Squashing preserves reachability between the remaining operations, so all the answers stay
+	// valid while we squash and can be calculated once up front.
+	reachesResourceOps := calculateReachesResourceOps(p, adjMap)
+
+	var squashableOpIDs []string
+	for opID := range adjMap {
+		if lo.Must(p.Operation(opID)).Category != OperationCategoryTrack || reachesResourceOps[opID] {
+			continue
+		}
+
+		squashableOpIDs = append(squashableOpIDs, opID)
+	}
+
+	for _, opID := range squashableOpIDs {
+		squashOperationInMaps(p, opID, adjMap, predMap)
+	}
+}
+
 func squashUselessMetaOperations(p *Plan) {
 	operationPairs := findMetaOperationPairs(p.Operations())
 	uselessOperationPairs := findUselessMetaOperations(operationPairs, lo.Must(p.Graph.AdjacencyMap()))
@@ -288,6 +310,38 @@ func squashUselessMetaOperations(p *Plan) {
 	if len(uselessOperationPairs) > 0 {
 		squashUselessMetaOperations(p)
 	}
+}
+
+func calculateReachesResourceOps(p *Plan, adjMap map[string]map[string]graph.Edge[string]) map[string]bool {
+	reaches := make(map[string]bool, len(adjMap))
+
+	var calculate func(opID string) bool
+
+	calculate = func(opID string) bool {
+		if result, calculated := reaches[opID]; calculated {
+			return result
+		}
+
+		result := lo.Must(p.Operation(opID)).Category == OperationCategoryResource
+
+		for adjID := range adjMap[opID] {
+			if result {
+				break
+			}
+
+			result = calculate(adjID)
+		}
+
+		reaches[opID] = result
+
+		return result
+	}
+
+	for opID := range adjMap {
+		calculate(opID)
+	}
+
+	return reaches
 }
 
 func findMetaOperationPairs(operations []*Operation) [][]*Operation {
@@ -342,29 +396,35 @@ func findUselessMetaOperations(operationPairs [][]*Operation, adjMap map[string]
 	return uselessPairs
 }
 
-func squashFinalTrackingOperations(p *Plan) {
-	ops := p.Operations()
-	trackingOps := lo.Filter(ops, func(op *Operation, _ int) bool {
-		return op.Category == OperationCategoryTrack
-	})
+func squashOperationInMaps(p *Plan, opID string, adjMap, predMap map[string]map[string]graph.Edge[string]) {
+	opPreds := predMap[opID]
+	opAdjacencies := adjMap[opID]
 
-	for _, trackingOp := range trackingOps {
-		var foundDependentResourceOps bool
-		lo.Must0(graph.BFS(p.Graph, trackingOp.ID(), func(opID string) bool {
-			op := lo.Must(p.Operation(opID))
-			if op.Category == OperationCategoryResource {
-				foundDependentResourceOps = true
+	for predID := range opPreds {
+		lo.Must0(p.Graph.RemoveEdge(predID, opID))
 
-				return true
-			}
+		delete(adjMap[predID], opID)
+	}
 
-			return false
-		}))
+	for adjID := range opAdjacencies {
+		lo.Must0(p.Graph.RemoveEdge(opID, adjID))
 
-		if !foundDependentResourceOps {
-			p.SquashOperation(trackingOp)
+		delete(predMap[adjID], opID)
+	}
+
+	for predID := range opPreds {
+		for adjID := range opAdjacencies {
+			lo.Must0(p.Connect(predID, adjID))
+
+			adjMap[predID][adjID] = graph.Edge[string]{Source: predID, Target: adjID}
+			predMap[adjID][predID] = graph.Edge[string]{Source: predID, Target: adjID}
 		}
 	}
+
+	lo.Must0(p.Graph.RemoveVertex(opID))
+
+	delete(adjMap, opID)
+	delete(predMap, opID)
 }
 
 func stageOperationID(stage common.Stage, suffix string) string {

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -229,30 +229,12 @@ func (b *planChainBuilder) Do() error {
 			vertexAdded = true
 		}
 
-		operations := b.plan.Operations()
-
 		if step.stage != "" && vertexAdded {
-			stageStartOp := lo.Must(lo.Find(operations, func(op *Operation) bool {
-				config, ok := op.Config.(*OperationConfigNoop)
-				if !ok {
-					return false
-				}
-
-				return config.OpID == fmt.Sprintf("%s/%s/%s", common.StagePrefix, step.stage, common.StageStartSuffix)
-			}))
-			if err := b.plan.Connect(stageStartOp.ID(), step.operation.ID()); err != nil {
+			if err := b.plan.Connect(stageOperationID(step.stage, common.StageStartSuffix), step.operation.ID()); err != nil {
 				return fmt.Errorf("connect starting stage: %w", err)
 			}
 
-			stageEndOp := lo.Must(lo.Find(operations, func(op *Operation) bool {
-				config, ok := op.Config.(*OperationConfigNoop)
-				if !ok {
-					return false
-				}
-
-				return config.OpID == fmt.Sprintf("%s/%s/%s", common.StagePrefix, step.stage, common.StageEndSuffix)
-			}))
-			if err := b.plan.Connect(step.operation.ID(), stageEndOp.ID()); err != nil {
+			if err := b.plan.Connect(step.operation.ID(), stageOperationID(step.stage, common.StageEndSuffix)); err != nil {
 				return fmt.Errorf("connect ending stage: %w", err)
 			}
 		}
@@ -383,4 +365,8 @@ func squashFinalTrackingOperations(p *Plan) {
 			p.SquashOperation(trackingOp)
 		}
 	}
+}
+
+func stageOperationID(stage common.Stage, suffix string) string {
+	return OperationID(OperationTypeNoop, OperationVersionNoop, 0, fmt.Sprintf("%s/%s/%s", common.StagePrefix, stage, suffix))
 }

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -258,7 +258,7 @@ func squashFinalTrackingOperations(p *Plan) {
 
 	// Squashing preserves reachability between the remaining operations, so all the answers stay
 	// valid while we squash and can be calculated once up front.
-	reachesResourceOps := calculateReachesResourceOps(p, adjMap)
+	reachesResourceOps := calculateReachesResourceOps(p, adjMap, predMap)
 
 	var squashableOpIDs []string
 	for opID := range adjMap {
@@ -292,33 +292,29 @@ func squashUselessMetaOperations(p *Plan) {
 	}
 }
 
-func calculateReachesResourceOps(p *Plan, adjMap map[string]map[string]graph.Edge[string]) map[string]bool {
+func calculateReachesResourceOps(p *Plan, adjMap, predMap map[string]map[string]graph.Edge[string]) map[string]bool {
 	reaches := make(map[string]bool, len(adjMap))
 
-	var calculate func(opID string) bool
-
-	calculate = func(opID string) bool {
-		if result, calculated := reaches[opID]; calculated {
-			return result
+	var queue []string
+	for opID := range adjMap {
+		if lo.Must(p.Operation(opID)).Category == OperationCategoryResource {
+			queue = append(queue, opID)
 		}
-
-		result := lo.Must(p.Operation(opID)).Category == OperationCategoryResource
-
-		for adjID := range adjMap[opID] {
-			if result {
-				break
-			}
-
-			result = calculate(adjID)
-		}
-
-		reaches[opID] = result
-
-		return result
 	}
 
-	for opID := range adjMap {
-		calculate(opID)
+	for len(queue) > 0 {
+		opID := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+
+		if reaches[opID] {
+			continue
+		}
+
+		reaches[opID] = true
+
+		for predID := range predMap[opID] {
+			queue = append(queue, predID)
+		}
 	}
 
 	return reaches

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -125,27 +125,7 @@ func (p *Plan) Optimize(noFinalTracking bool) error {
 }
 
 func (p *Plan) SquashOperation(op *Operation) {
-	adjMap := lo.Must(p.Graph.AdjacencyMap())
-	predMap := lo.Must(p.Graph.PredecessorMap())
-
-	opPreds := predMap[op.ID()]
-	opAdjacencies := adjMap[op.ID()]
-
-	for predID := range opPreds {
-		lo.Must0(p.Graph.RemoveEdge(predID, op.ID()))
-	}
-
-	for adjID := range opAdjacencies {
-		lo.Must0(p.Graph.RemoveEdge(op.ID(), adjID))
-	}
-
-	for predID := range opPreds {
-		for adjID := range opAdjacencies {
-			lo.Must0(p.Connect(predID, adjID))
-		}
-	}
-
-	lo.Must0(p.Graph.RemoveVertex(op.ID()))
+	squashOperationInMaps(p, op.ID(), lo.Must(p.Graph.AdjacencyMap()), lo.Must(p.Graph.PredecessorMap()))
 }
 
 func (p *Plan) ToDOT() ([]byte, error) {

--- a/pkg/plan/plan_ai_test.go
+++ b/pkg/plan/plan_ai_test.go
@@ -1,0 +1,123 @@
+//go:build ai_tests
+
+package plan
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_SquashFinalTrackingOperationsMatchesReference(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		opsCount   int
+		edgeChance float64
+	}{
+		{name: "sparse graph", opsCount: 14, edgeChance: 0.12},
+		{name: "dense graph", opsCount: 14, edgeChance: 0.55},
+		{name: "sparse large graph", opsCount: 70, edgeChance: 0.04},
+		{name: "dense large graph", opsCount: 70, edgeChance: 0.25},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for seed := int64(1); seed <= 40; seed++ {
+				categories, deps := randomTrackingGraph(rand.New(rand.NewSource(seed)), tt.opsCount, tt.edgeChance) //nolint:gosec
+
+				actual := buildTestPlan(trackingTestOperations(categories), deps)
+				squashFinalTrackingOperations(actual)
+
+				expected := buildTestPlan(trackingTestOperations(categories), deps)
+				squashFinalTrackingOperationsReference(expected)
+
+				require.Equal(t, lo.Must(expected.Graph.AdjacencyMap()), lo.Must(actual.Graph.AdjacencyMap()), "seed %d", seed)
+			}
+		})
+	}
+}
+
+func TestAI_SquashFinalTrackingOperationsSemantics(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		categories    []OperationCategory
+		deps          map[int][]int
+		expectedOps   []int
+		expectedEdges [][2]int
+	}{
+		{
+			name:          "squashes tracking with no resource operation below it",
+			categories:    []OperationCategory{OperationCategoryResource, OperationCategoryTrack},
+			deps:          map[int][]int{1: {0}},
+			expectedOps:   []int{0},
+			expectedEdges: nil,
+		},
+		{
+			name:          "keeps tracking that a resource operation depends on",
+			categories:    []OperationCategory{OperationCategoryResource, OperationCategoryTrack, OperationCategoryResource},
+			deps:          map[int][]int{1: {0}, 2: {1}},
+			expectedOps:   []int{0, 1, 2},
+			expectedEdges: [][2]int{{0, 1}, {1, 2}},
+		},
+		{
+			name:          "keeps tracking that reaches a resource operation through a meta operation",
+			categories:    []OperationCategory{OperationCategoryTrack, OperationCategoryMeta, OperationCategoryResource},
+			deps:          map[int][]int{1: {0}, 2: {1}},
+			expectedOps:   []int{0, 1, 2},
+			expectedEdges: [][2]int{{0, 1}, {1, 2}},
+		},
+		{
+			name:          "reconnects predecessors to successors of the squashed tracking",
+			categories:    []OperationCategory{OperationCategoryResource, OperationCategoryTrack, OperationCategoryMeta},
+			deps:          map[int][]int{1: {0}, 2: {1}},
+			expectedOps:   []int{0, 2},
+			expectedEdges: [][2]int{{0, 2}},
+		},
+		{
+			name:          "squashes tracking followed only by a release operation",
+			categories:    []OperationCategory{OperationCategoryResource, OperationCategoryTrack, OperationCategoryRelease},
+			deps:          map[int][]int{1: {0}, 2: {1}},
+			expectedOps:   []int{0, 2},
+			expectedEdges: [][2]int{{0, 2}},
+		},
+		{
+			name:          "squashes a whole chain of trailing tracking operations",
+			categories:    []OperationCategory{OperationCategoryResource, OperationCategoryTrack, OperationCategoryTrack},
+			deps:          map[int][]int{1: {0}, 2: {1}},
+			expectedOps:   []int{0},
+			expectedEdges: nil,
+		},
+		{
+			name:          "squashes only the trailing tracking of a branching graph",
+			categories:    []OperationCategory{OperationCategoryResource, OperationCategoryTrack, OperationCategoryTrack, OperationCategoryResource},
+			deps:          map[int][]int{1: {0}, 2: {0}, 3: {2}},
+			expectedOps:   []int{0, 2, 3},
+			expectedEdges: [][2]int{{0, 2}, {2, 3}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := trackingTestOperations(tt.categories)
+
+			p := buildTestPlan(ops, tt.deps)
+			squashFinalTrackingOperations(p)
+
+			adjMap := lo.Must(p.Graph.AdjacencyMap())
+
+			assert.ElementsMatch(t, lo.Map(tt.expectedOps, func(i, _ int) string {
+				return ops[i].ID()
+			}), lo.Keys(adjMap))
+
+			var actualEdges []string
+			for fromID, adjacencies := range adjMap {
+				for toID := range adjacencies {
+					actualEdges = append(actualEdges, fromID+" -> "+toID)
+				}
+			}
+
+			assert.ElementsMatch(t, lo.Map(tt.expectedEdges, func(edge [2]int, _ int) string {
+				return ops[edge[0]].ID() + " -> " + ops[edge[1]].ID()
+			}), actualEdges)
+		})
+	}
+}

--- a/pkg/plan/plan_ai_test.go
+++ b/pkg/plan/plan_ai_test.go
@@ -3,12 +3,15 @@
 package plan
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/werf/nelm/pkg/common"
 )
 
 func TestAI_SquashFinalTrackingOperationsMatchesReference(t *testing.T) {
@@ -119,5 +122,22 @@ func TestAI_SquashFinalTrackingOperationsSemantics(t *testing.T) {
 				return ops[edge[0]].ID() + " -> " + ops[edge[1]].ID()
 			}), actualEdges)
 		})
+	}
+}
+
+func TestAI_StageOperationID(t *testing.T) {
+	for _, stage := range common.StagesOrdered {
+		for _, suffix := range []string{common.StageStartSuffix, common.StageEndSuffix} {
+			op := &Operation{
+				Type:     OperationTypeNoop,
+				Version:  OperationVersionNoop,
+				Category: OperationCategoryMeta,
+				Config: &OperationConfigNoop{
+					OpID: fmt.Sprintf("%s/%s/%s", common.StagePrefix, stage, suffix),
+				},
+			}
+
+			assert.Equal(t, op.ID(), stageOperationID(stage, suffix))
+		}
 	}
 }

--- a/pkg/plan/plan_build.go
+++ b/pkg/plan/plan_build.go
@@ -139,20 +139,16 @@ func addFailureReleaseOperations(failedPlan, plan *Plan, releaseInfos []*Release
 			continue
 		}
 
-		if _, releaseCreated := lo.Find(failedPlan.Operations(), func(op *Operation) bool {
-			if op.Status != OperationStatusCompleted {
-				return false
-			}
+		releaseOpIDs := []string{
+			OperationID(OperationTypeCreateRelease, OperationVersionCreateRelease, 0, info.Release.ID()),
+			OperationID(OperationTypeUpdateRelease, OperationVersionUpdateRelease, 0, info.Release.ID()),
+		}
 
-			switch config := op.Config.(type) {
-			case *OperationConfigCreateRelease:
-				return config.Release.ID() == info.Release.ID()
-			case *OperationConfigUpdateRelease:
-				return config.Release.ID() == info.Release.ID()
-			default:
-				return false
-			}
-		}); !releaseCreated {
+		if !lo.SomeBy(releaseOpIDs, func(opID string) bool {
+			op, found := failedPlan.Operation(opID)
+
+			return found && op.Status == OperationStatusCompleted
+		}) {
 			continue
 		}
 
@@ -339,11 +335,7 @@ func addFailureResourceOperations(failedPlan, plan *Plan, infos []*InstallableRe
 		}
 
 		if info.MustDeleteOnSuccessfulInstall {
-			deleteOnSuccessfulInstallOp := lo.Must(lo.Find(failedPlan.Operations(), func(op *Operation) bool {
-				return op.Type == OperationTypeDelete &&
-					op.Iteration == OperationIteration(info.Iteration) &&
-					op.Config.(*OperationConfigDelete).ResourceMeta.ID() == info.ID()
-			}))
+			deleteOnSuccessfulInstallOp := lo.Must(failedPlan.Operation(OperationID(OperationTypeDelete, OperationVersionDelete, OperationIteration(info.Iteration), info.ID())))
 
 			if deleteOnSuccessfulInstallOp.Status == OperationStatusCompleted {
 				continue

--- a/pkg/plan/plan_build_ai_test.go
+++ b/pkg/plan/plan_build_ai_test.go
@@ -1,0 +1,174 @@
+//go:build ai_tests
+
+package plan
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	helmrelease "github.com/werf/nelm/pkg/helm/pkg/release"
+)
+
+func TestAI_BuildFailurePlan(t *testing.T) {
+	failedRelease := &helmrelease.Release{
+		Name:      "test-release",
+		Namespace: "test-namespace",
+		Version:   1,
+		Info:      &helmrelease.Info{Status: helmrelease.StatusPendingInstall},
+	}
+
+	for _, tt := range []struct {
+		name               string
+		failedPlanOps      []*Operation
+		installableInfos   []*InstallableResourceInfo
+		releaseInfos       []*ReleaseInfo
+		expectedOperations []string
+	}{
+		{
+			name:             "deletes a resource whose readiness tracking failed",
+			failedPlanOps:    []*Operation{trackReadinessTestOp("a", OperationStatusFailed)},
+			installableInfos: []*InstallableResourceInfo{installableInfoToDeleteOnFailedInstall("a")},
+			expectedOperations: []string{
+				OperationID(OperationTypeDelete, OperationVersionDelete, 0, "test-namespace::ConfigMap:a"),
+				OperationID(OperationTypeTrackAbsence, OperationVersionTrackAbsence, 0, "test-namespace::ConfigMap:a"),
+			},
+		},
+		{
+			name:               "keeps a resource whose readiness tracking succeeded",
+			failedPlanOps:      []*Operation{trackReadinessTestOp("a", OperationStatusCompleted)},
+			installableInfos:   []*InstallableResourceInfo{installableInfoToDeleteOnFailedInstall("a")},
+			expectedOperations: []string{},
+		},
+		{
+			name:               "keeps a resource that must not be deleted on failed install",
+			failedPlanOps:      []*Operation{trackReadinessTestOp("a", OperationStatusFailed)},
+			installableInfos:   []*InstallableResourceInfo{installableInfoNamed("a", ResourceInstallTypeApply)},
+			expectedOperations: []string{},
+		},
+		{
+			name: "keeps a resource that was already deleted on successful install",
+			failedPlanOps: []*Operation{
+				trackReadinessTestOp("a", OperationStatusFailed),
+				deleteTestOp("a", OperationStatusCompleted),
+			},
+			installableInfos:   []*InstallableResourceInfo{installableInfoToDeleteOnAnyOutcome("a")},
+			expectedOperations: []string{},
+		},
+		{
+			name: "deletes a resource whose delete on successful install never ran",
+			failedPlanOps: []*Operation{
+				trackReadinessTestOp("a", OperationStatusFailed),
+				deleteTestOp("a", OperationStatusPending),
+			},
+			installableInfos: []*InstallableResourceInfo{installableInfoToDeleteOnAnyOutcome("a")},
+			expectedOperations: []string{
+				OperationID(OperationTypeDelete, OperationVersionDelete, 0, "test-namespace::ConfigMap:a"),
+				OperationID(OperationTypeTrackAbsence, OperationVersionTrackAbsence, 0, "test-namespace::ConfigMap:a"),
+			},
+		},
+		{
+			name: "deletes only the resources that failed",
+			failedPlanOps: []*Operation{
+				trackReadinessTestOp("a", OperationStatusFailed),
+				trackReadinessTestOp("b", OperationStatusCompleted),
+			},
+			installableInfos: []*InstallableResourceInfo{
+				installableInfoToDeleteOnFailedInstall("a"),
+				installableInfoToDeleteOnFailedInstall("b"),
+			},
+			expectedOperations: []string{
+				OperationID(OperationTypeDelete, OperationVersionDelete, 0, "test-namespace::ConfigMap:a"),
+				OperationID(OperationTypeTrackAbsence, OperationVersionTrackAbsence, 0, "test-namespace::ConfigMap:a"),
+			},
+		},
+		{
+			name:          "fails a release created by the failed plan",
+			failedPlanOps: []*Operation{createReleaseTestOp(failedRelease, OperationStatusCompleted)},
+			releaseInfos:  []*ReleaseInfo{{Release: failedRelease, MustFailOnFailedDeploy: true}},
+			expectedOperations: []string{
+				OperationID(OperationTypeUpdateRelease, OperationVersionUpdateRelease, 0, failedRelease.ID()),
+			},
+		},
+		{
+			name:          "fails a release updated by the failed plan",
+			failedPlanOps: []*Operation{updateReleaseTestOp(failedRelease, OperationStatusCompleted)},
+			releaseInfos:  []*ReleaseInfo{{Release: failedRelease, MustFailOnFailedDeploy: true}},
+			expectedOperations: []string{
+				OperationID(OperationTypeUpdateRelease, OperationVersionUpdateRelease, 0, failedRelease.ID()),
+			},
+		},
+		{
+			name:               "keeps a release that the failed plan never created",
+			failedPlanOps:      []*Operation{createReleaseTestOp(failedRelease, OperationStatusPending)},
+			releaseInfos:       []*ReleaseInfo{{Release: failedRelease, MustFailOnFailedDeploy: true}},
+			expectedOperations: []string{},
+		},
+		{
+			name:               "keeps a release that must not fail on a failed deploy",
+			failedPlanOps:      []*Operation{createReleaseTestOp(failedRelease, OperationStatusCompleted)},
+			releaseInfos:       []*ReleaseInfo{{Release: failedRelease}},
+			expectedOperations: []string{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			failurePlan, err := BuildFailurePlan(buildTestPlan(tt.failedPlanOps, nil), tt.installableInfos, tt.releaseInfos, BuildFailurePlanOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedOperations, meaningfulOperationIDs(failurePlan))
+		})
+	}
+}
+
+func createReleaseTestOp(rel *helmrelease.Release, status OperationStatus) *Operation {
+	return &Operation{
+		Type:     OperationTypeCreateRelease,
+		Version:  OperationVersionCreateRelease,
+		Category: OperationCategoryRelease,
+		Status:   status,
+		Config:   &OperationConfigCreateRelease{Release: rel},
+	}
+}
+
+func deleteTestOp(name string, status OperationStatus) *Operation {
+	return &Operation{
+		Type:     OperationTypeDelete,
+		Version:  OperationVersionDelete,
+		Category: OperationCategoryResource,
+		Status:   status,
+		Config:   &OperationConfigDelete{ResourceMeta: makeResourceMeta(name, "test-namespace", gvkConfigMap)},
+	}
+}
+
+func meaningfulOperationIDs(p *Plan) []string {
+	ids := lo.FilterMap(p.Operations(), func(op *Operation, _ int) (string, bool) {
+		return op.ID(), op.Category != OperationCategoryMeta
+	})
+
+	sort.Strings(ids)
+
+	return ids
+}
+
+func trackReadinessTestOp(name string, status OperationStatus) *Operation {
+	return &Operation{
+		Type:     OperationTypeTrackReadiness,
+		Version:  OperationVersionTrackReadiness,
+		Category: OperationCategoryTrack,
+		Status:   status,
+		Config:   &OperationConfigTrackReadiness{ResourceMeta: makeResourceMeta(name, "test-namespace", gvkConfigMap)},
+	}
+}
+
+func updateReleaseTestOp(rel *helmrelease.Release, status OperationStatus) *Operation {
+	return &Operation{
+		Type:     OperationTypeUpdateRelease,
+		Version:  OperationVersionUpdateRelease,
+		Category: OperationCategoryRelease,
+		Status:   status,
+		Config:   &OperationConfigUpdateRelease{Release: rel},
+	}
+}

--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -471,20 +471,21 @@ func exclusiveOwnershipForOurManager(managedFields []v1.ManagedFieldsEntry, ours
 }
 
 func filterDelResourcesPresentInInstResources(instResourceInfos []*InstallableResourceInfo, delResourceInfos []*DeletableResourceInfo) []*DeletableResourceInfo {
-	var instResourcesUIDs []types.UID
+	instResourcesUIDs := make(map[types.UID]struct{}, len(instResourceInfos))
 	for _, instInfo := range instResourceInfos {
 		if instInfo.GetResult == nil {
 			continue
 		}
 
-		instResourcesUIDs = append(instResourcesUIDs, instInfo.GetResult.GetUID())
+		instResourcesUIDs[instInfo.GetResult.GetUID()] = struct{}{}
 	}
 
 	var filteredDelResourceInfos []*DeletableResourceInfo
 	for _, delInfo := range delResourceInfos {
-		if delInfo.GetResult != nil &&
-			lo.Contains(instResourcesUIDs, delInfo.GetResult.GetUID()) {
-			continue
+		if delInfo.GetResult != nil {
+			if _, found := instResourcesUIDs[delInfo.GetResult.GetUID()]; found {
+				continue
+			}
 		}
 
 		filteredDelResourceInfos = append(filteredDelResourceInfos, delInfo)
@@ -680,16 +681,17 @@ func isServiceAccountFieldManaged(entry v1.ManagedFieldsEntry, subPath []string)
 }
 
 func iterateInstallableResourceInfos(infos []*InstallableResourceInfo) {
-	var seenInfos []*InstallableResourceInfo
+	seenInfos := make(map[string]*InstallableResourceInfo, len(infos))
 	for _, info := range infos {
-		seenInfo, seen := lo.Find(seenInfos, func(inf *InstallableResourceInfo) bool {
-			return info.ID() == inf.ID()
-		})
-		if seen {
+		id := info.ID()
+
+		if seenInfo, seen := seenInfos[id]; seen {
 			info.Iteration = seenInfo.Iteration + 1
+
+			continue
 		}
 
-		seenInfos = append(seenInfos, info)
+		seenInfos[id] = info
 	}
 
 	var highestIteration int

--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -714,9 +714,7 @@ func iterateInstallableResourceInfos(infos []*InstallableResourceInfo) {
 				continue
 			}
 
-			prevIterInfo := lo.Must(lo.Find(infos, func(inf *InstallableResourceInfo) bool {
-				return iterInfo.ID() == inf.ID() && inf.Iteration == iterInfo.Iteration-1
-			}))
+			prevIterInfo := seenInfos[iterInfo.ID()]
 
 			if prevIterInfo.MustDeleteOnSuccessfulInstall && !lo.Contains(iterInfo.LocalResource.ResourcePolicies, common.ResourcePolicySkipCreate) {
 				iterInfo.MustInstall = ResourceInstallTypeCreate

--- a/pkg/plan/resource_info.go
+++ b/pkg/plan/resource_info.go
@@ -482,10 +482,8 @@ func filterDelResourcesPresentInInstResources(instResourceInfos []*InstallableRe
 
 	var filteredDelResourceInfos []*DeletableResourceInfo
 	for _, delInfo := range delResourceInfos {
-		if delInfo.GetResult != nil {
-			if _, found := instResourcesUIDs[delInfo.GetResult.GetUID()]; found {
-				continue
-			}
+		if delInfo.GetResult != nil && lo.HasKey(instResourcesUIDs, delInfo.GetResult.GetUID()) {
+			continue
 		}
 
 		filteredDelResourceInfos = append(filteredDelResourceInfos, delInfo)

--- a/pkg/plan/resource_info_ai_test.go
+++ b/pkg/plan/resource_info_ai_test.go
@@ -107,6 +107,98 @@ func TestAI_FilterDelResourcesPresentInInstResources(t *testing.T) {
 	}
 }
 
+func TestAI_IterateInstallableResourceInfos(t *testing.T) {
+	for _, tt := range []struct {
+		name                 string
+		infos                []*InstallableResourceInfo
+		expectedIterations   []int
+		expectedInstallTypes []ResourceInstallType
+	}{
+		{
+			name:                 "leaves a lone resource on the first iteration",
+			infos:                []*InstallableResourceInfo{installableInfoNamed("a", ResourceInstallTypeApply)},
+			expectedIterations:   []int{0},
+			expectedInstallTypes: []ResourceInstallType{ResourceInstallTypeApply},
+		},
+		{
+			name: "moves the second resource sharing an id to the next iteration",
+			infos: []*InstallableResourceInfo{
+				installableInfoNamed("a", ResourceInstallTypeApply),
+				installableInfoNamed("a", ResourceInstallTypeApply),
+			},
+			expectedIterations:   []int{0, 1},
+			expectedInstallTypes: []ResourceInstallType{ResourceInstallTypeApply, ResourceInstallTypeApply},
+		},
+		{
+			name: "keeps the third resource sharing an id on the second iteration",
+			infos: []*InstallableResourceInfo{
+				installableInfoNamed("a", ResourceInstallTypeApply),
+				installableInfoNamed("a", ResourceInstallTypeApply),
+				installableInfoNamed("a", ResourceInstallTypeApply),
+			},
+			expectedIterations:   []int{0, 1, 1},
+			expectedInstallTypes: []ResourceInstallType{ResourceInstallTypeApply, ResourceInstallTypeApply, ResourceInstallTypeApply},
+		},
+		{
+			name: "iterates every id on its own",
+			infos: []*InstallableResourceInfo{
+				installableInfoNamed("a", ResourceInstallTypeApply),
+				installableInfoNamed("b", ResourceInstallTypeApply),
+				installableInfoNamed("a", ResourceInstallTypeApply),
+				installableInfoNamed("b", ResourceInstallTypeApply),
+				installableInfoNamed("a", ResourceInstallTypeApply),
+			},
+			expectedIterations: []int{0, 0, 1, 1, 1},
+			expectedInstallTypes: []ResourceInstallType{
+				ResourceInstallTypeApply,
+				ResourceInstallTypeApply,
+				ResourceInstallTypeApply,
+				ResourceInstallTypeApply,
+				ResourceInstallTypeApply,
+			},
+		},
+		{
+			name: "creates the next iteration of a resource deleted on successful install",
+			infos: []*InstallableResourceInfo{
+				installableInfoToDeleteOnSuccessfulInstall("a"),
+				installableInfoNamed("a", ResourceInstallTypeApply),
+			},
+			expectedIterations:   []int{0, 1},
+			expectedInstallTypes: []ResourceInstallType{ResourceInstallTypeApply, ResourceInstallTypeCreate},
+		},
+		{
+			name: "keeps the install type of a resource with skip-create",
+			infos: []*InstallableResourceInfo{
+				installableInfoToDeleteOnSuccessfulInstall("a"),
+				installableInfoNamed("a", ResourceInstallTypeApply, common.ResourcePolicySkipCreate),
+			},
+			expectedIterations:   []int{0, 1},
+			expectedInstallTypes: []ResourceInstallType{ResourceInstallTypeApply, ResourceInstallTypeApply},
+		},
+		{
+			name: "keeps a resource that must not be installed uninstalled",
+			infos: []*InstallableResourceInfo{
+				installableInfoToDeleteOnSuccessfulInstall("a"),
+				installableInfoNamed("a", ResourceInstallTypeNone),
+			},
+			expectedIterations:   []int{0, 1},
+			expectedInstallTypes: []ResourceInstallType{ResourceInstallTypeApply, ResourceInstallTypeNone},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			iterateInstallableResourceInfos(tt.infos)
+
+			assert.Equal(t, tt.expectedIterations, lo.Map(tt.infos, func(info *InstallableResourceInfo, _ int) int {
+				return info.Iteration
+			}))
+
+			assert.Equal(t, tt.expectedInstallTypes, lo.Map(tt.infos, func(info *InstallableResourceInfo, _ int) ResourceInstallType {
+				return info.MustInstall
+			}))
+		})
+	}
+}
+
 func TestAI_PoolRoutines(t *testing.T) {
 	for _, tt := range []struct {
 		name               string

--- a/pkg/plan/resource_info_ai_test.go
+++ b/pkg/plan/resource_info_ai_test.go
@@ -5,8 +5,10 @@ package plan
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/werf/nelm/pkg/common"
 	"github.com/werf/nelm/pkg/featgate"
@@ -39,6 +41,70 @@ func TestAI_ExclusiveOwnershipForOurManagerDeckhouseControllerGateEnabled(t *tes
 
 	assert.False(t, changed)
 	assert.False(t, hasManager(newManagedFields, common.OldDeckhouseControllerManager))
+}
+
+func TestAI_FilterDelResourcesPresentInInstResources(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		instInfos    []*InstallableResourceInfo
+		delInfos     []*DeletableResourceInfo
+		expectedUIDs []types.UID
+	}{
+		{
+			name:         "keeps every deletable when there are no installables",
+			instInfos:    nil,
+			delInfos:     []*DeletableResourceInfo{deletableInfoWithUID("a"), deletableInfoWithUID("b")},
+			expectedUIDs: []types.UID{"a", "b"},
+		},
+		{
+			name:         "returns nothing when there are no deletables",
+			instInfos:    []*InstallableResourceInfo{installableInfoWithUID("a")},
+			delInfos:     nil,
+			expectedUIDs: []types.UID{},
+		},
+		{
+			name:         "drops the deletable sharing a uid with an installable",
+			instInfos:    []*InstallableResourceInfo{installableInfoWithUID("a"), installableInfoWithUID("b")},
+			delInfos:     []*DeletableResourceInfo{deletableInfoWithUID("a"), deletableInfoWithUID("c")},
+			expectedUIDs: []types.UID{"c"},
+		},
+		{
+			name:         "drops every deletable when all of them share uids with installables",
+			instInfos:    []*InstallableResourceInfo{installableInfoWithUID("a"), installableInfoWithUID("b")},
+			delInfos:     []*DeletableResourceInfo{deletableInfoWithUID("b"), deletableInfoWithUID("a")},
+			expectedUIDs: []types.UID{},
+		},
+		{
+			name:         "ignores installables that were not found in the cluster",
+			instInfos:    []*InstallableResourceInfo{{}, installableInfoWithUID("b")},
+			delInfos:     []*DeletableResourceInfo{deletableInfoWithUID("a")},
+			expectedUIDs: []types.UID{"a"},
+		},
+		{
+			name:         "keeps deletables that were not found in the cluster",
+			instInfos:    []*InstallableResourceInfo{installableInfoWithUID("a")},
+			delInfos:     []*DeletableResourceInfo{{}, deletableInfoWithUID("a")},
+			expectedUIDs: []types.UID{""},
+		},
+		{
+			name:         "preserves the order of the kept deletables",
+			instInfos:    []*InstallableResourceInfo{installableInfoWithUID("b")},
+			delInfos:     []*DeletableResourceInfo{deletableInfoWithUID("a"), deletableInfoWithUID("b"), deletableInfoWithUID("c")},
+			expectedUIDs: []types.UID{"a", "c"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := filterDelResourcesPresentInInstResources(tt.instInfos, tt.delInfos)
+
+			assert.Equal(t, tt.expectedUIDs, lo.Map(filtered, func(info *DeletableResourceInfo, _ int) types.UID {
+				if info.GetResult == nil {
+					return ""
+				}
+
+				return info.GetResult.GetUID()
+			}))
+		})
+	}
 }
 
 func TestAI_PoolRoutines(t *testing.T) {


### PR DESCRIPTION
## Summary

Deploying releases with many resources no longer takes minutes. Plan building was quadratic in the number of resources, so large releases hit the deploy timeout instead of rolling out.

## What

- A release with ~19K objects used to exceed the 20-minute deploy timeout with `--no-final-tracking`. It now plans in ~25s.
- At 4000 resources, planning drops from ~37s to ~2.3s with `--no-final-tracking`, and from ~21s to ~1.7s without it.
- The failure plan builder had the same problem: both of its operation lookups scanned every operation of the failed plan on each iteration. It now probes the graph by derived operation id, so a deploy that fails on a large release can still build its failure plan.
- Adds coverage for the rewritten code: the final tracking squash is asserted against the pre-optimization implementation, and `iterateInstallableResourceInfos` and `BuildFailurePlan` get their first tests.
- No behaviour changes: same plan, same operations, same ordering — only faster. The one exception: a missing stage boundary operation now returns a wrapped error instead of panicking in `lo.Must`.

## Why

Three linear scans nested in per-resource loops, plus a per-operation graph rebuild in the `--no-final-tracking` pass, made planning grow quadratically. The larger the release, the worse it got, until it stopped finishing at all.

Plan building is still not linear overall: `Optimize` runs `graph.TransitiveReduction` (documented as O(V*(V+E))), and the plan graph is built with `graph.PreventCycles()`, so every `AddEdge` runs a cycle-detection DFS. What this PR removes is the per-resource quadratic scans, the per-operation graph rebuild, and the same scans in the failure plan builder.
